### PR TITLE
Fix simplified characters

### DIFF
--- a/jyut6ping3.dict.yaml
+++ b/jyut6ping3.dict.yaml
@@ -407,7 +407,6 @@ import_tables:
 襬	baai2	
 捭	baai2	
 擺	baai2	
-襬	baai2	
 㗑	baai3	
 㠔	baai3	
 拜	baai3	
@@ -1066,7 +1065,6 @@ import_tables:
 縍	bong1	
 邦	bong1	
 鞤	bong1	
-𨧜	bong1	
 㮄	bong2	
 榜	bong2	
 牓	bong2	
@@ -1366,7 +1364,6 @@ import_tables:
 儕	caai4	
 㾹	caai4	
 䓱	caai4	
-儕	caai4	
 喍	caai4	
 柴	caai4	
 茈	caai4	
@@ -1392,7 +1389,6 @@ import_tables:
 柵	caak3	
 烢	caak3	
 策	caak3	
-筴	caak3	
 簎	caak3	
 茦	caak3	
 蠈	caak3	
@@ -1639,7 +1635,6 @@ import_tables:
 讖	cam3	
 𩂈	cam3	
 㜄	cam4	
-㜄	cam4	
 㜦	cam4	
 䒞	cam4	
 䕭	cam4	
@@ -1747,8 +1742,6 @@ import_tables:
 𨳍	cat6	
 𫵱	cat6	
 㑳	cau1	
-㑳	cau1	
-㥮	cau1	
 㥮	cau1	
 㨨	cau1	
 㩅	cau1	
@@ -1768,7 +1761,6 @@ import_tables:
 秋	cau1	
 秌	cau1	
 篘	cau1	
-紬	cau1	
 緧	cau1	
 萩	cau1	
 蟗	cau1	
@@ -1821,14 +1813,12 @@ import_tables:
 崷	cau4	
 幬	cau4	
 惆	cau4	
-懤	cau4	
 椆	cau4	
 泅	cau4	
 犨	cau4	
 疇	cau4	
 稠	cau4	
 籌	cau4	
-紬	cau4	
 綢	cau4	
 菗	cau4	
 蝤	cau4	
@@ -1929,7 +1919,6 @@ import_tables:
 䄟	ceoi3	
 䕜	ceoi3	
 䦟	ceoi3	
-䦟	ceoi3	
 䴝	ceoi3	
 倅	ceoi3	
 吹	ceoi3	
@@ -1937,7 +1926,6 @@ import_tables:
 娶	ceoi3	
 橇	ceoi3	
 毳	ceoi3	
-淬	ceoi3	
 焠	ceoi3	
 竁	ceoi3	
 綷	ceoi3	
@@ -1990,7 +1978,6 @@ import_tables:
 橁	ceon1	
 蝽	ceon1	
 輴	ceon1	
-鰆	ceon1	
 鶞	ceon1	
 𢰦	ceon1	
 𣇸	ceon1	
@@ -2065,7 +2052,6 @@ import_tables:
 鴟	ci1	
 黐	ci1	
 齝	ci1	
-絺	ci1	
 㢁	ci2	
 㢋	ci2	
 㶴	ci2	
@@ -2249,7 +2235,6 @@ import_tables:
 𥄎	cik1	
 𦭐	cik1	
 𪆵	cik1	
-鶒	cik1	
 刺	cik3	
 蚇	cik3	
 赤	cik3	
@@ -2399,7 +2384,6 @@ import_tables:
 靘	cing3	
 䄇	cing4	
 䇸	cing4	
-䝼	cing4	
 䝼	cing4	
 呈	cing4	
 埕	cing4	
@@ -2663,7 +2647,6 @@ import_tables:
 彩	coi2	
 採	coi2	
 睬	coi2	
-綵	coi2	
 茝	coi2	
 茞	coi2	
 采	coi2	
@@ -2699,7 +2682,6 @@ import_tables:
 錯	cok3	
 䄝	cong1	
 䚎	cong1	
-䱽	cong1	
 䱽	cong1	
 倉	cong1	
 傖	cong1	
@@ -2845,7 +2827,6 @@ import_tables:
 𦌊	cuk1	
 𨀂	cuk1	
 𫂙	cuk1	
-餗	cuk1	
 㜡	cung1	
 㤝	cung1	
 㥖	cung1	
@@ -2901,7 +2882,6 @@ import_tables:
 𦿞	cung1	
 𧘂	cung1	
 𪻐	cung1	
-鏦	cung1	
 冢	cung2	
 塚	cung2	
 寵	cung2	
@@ -3097,10 +3077,8 @@ import_tables:
 艜	daai3	
 襶	daai3	
 蹛	daai3	
-𡠹	daai3	
 𥛣	daai3	
 𦄂	daai3	
-𧜵	daai3	
 㐲	daai6	
 㞭	daai6	
 㶡	daai6	
@@ -3108,7 +3086,6 @@ import_tables:
 䲦	daai6	
 大	daai6	
 汏	daai6	
-軑	daai6	
 軑	daai6	
 釱	daai6	
 𠯈	daai6	
@@ -3182,7 +3159,6 @@ import_tables:
 誕	daan3	
 鉭	daan3	
 鴠	daan3	
-𧩙	daan3	
 但	daan6	
 僤	daan6	
 彈	daan6	
@@ -3265,7 +3241,6 @@ import_tables:
 低	dai1	
 彽	dai1	
 氐	dai1	
-磾	dai1	
 羝	dai1	
 袛	dai1	
 鞮	dai1	
@@ -3303,7 +3278,6 @@ import_tables:
 蒂	dai3	
 蔕	dai3	
 蝃	dai3	
-螮	dai3	
 諦	dai3	
 𥰆	dai3	
 𧬺	dai3	
@@ -4035,11 +4009,9 @@ import_tables:
 䮷	duk6	
 匵	duk6	
 櫝	duk6	
-殰	duk6	
 毒	duk6	
 瀆	duk6	
 牘	duk6	
-犢	duk6	
 獨	duk6	
 皾	duk6	
 碡	duk6	
@@ -4284,7 +4256,6 @@ import_tables:
 墯	fai1	
 徽	fai1	
 揮	fai1	
-撝	fai1	
 暉	fai1	
 楎	fai1	
 煇	fai1	
@@ -4316,7 +4287,6 @@ import_tables:
 櫠	fai3	
 沸	fai3	
 疿	fai3	
-癈	fai3	
 砩	fai3	
 肺	fai3	
 胇	fai3	
@@ -4387,7 +4357,6 @@ import_tables:
 𤑛	fan1	
 𤦈	fan1	
 𨧼	fan1	
-纁	fan1	
 㥹	fan2	
 粉	fan2	
 㱵	fan3	
@@ -4663,7 +4632,6 @@ import_tables:
 蠼	fok3	
 貜	fok3	
 躩	fok3	
-钁	fok3	
 霍	fok3	
 靃	fok3	
 𦞦	fok3	
@@ -4803,7 +4771,6 @@ import_tables:
 骷	fu1	
 鳺	fu1	
 麩	fu1	
-鈇	fu1	
 㓡	fu2	
 㕮	fu2	
 䇢	fu2	
@@ -4952,7 +4919,6 @@ import_tables:
 𡟼	fui3	
 㙏	fuk1	
 䋹	fuk1	
-䋹	fuk1	
 䕎	fuk1	
 䨱	fuk1	
 䫝	fuk1	
@@ -5035,7 +5001,6 @@ import_tables:
 䗬	fung1	
 䵄	fung1	
 丰	fung1	
-偑	fung1	
 夆	fung1	
 妦	fung1	
 封	fung1	
@@ -5338,7 +5303,6 @@ import_tables:
 梜	gaap3	
 浹	gaap3	
 甲	gaap3	
-筴	gaap3	
 胛	gaap3	
 舺	gaap3	
 莢	gaap3	
@@ -5381,7 +5345,6 @@ import_tables:
 轇	gaau1	
 郊	gaau1	
 鮫	gaau1	
-鵁	gaau1	
 㚣	gaau2	
 㩭	gaau2	
 㽱	gaau2	
@@ -5632,7 +5595,6 @@ import_tables:
 緱	gau1	
 袧	gau1	
 韝	gau1	
-鬮	gau1	
 鳩	gau1	
 龜	gau1	
 𤄄	gau1	
@@ -5742,7 +5704,6 @@ import_tables:
 𢖯	gei1	
 𣻺	gei1	
 𥕛	gei1	
-𧝞	gei1	
 㞆	gei2	
 㞛	gei2	
 㞦	gei2	
@@ -6089,7 +6050,6 @@ import_tables:
 䮦	giu1	
 儌	giu1	
 嬌	giu1	
-憍	giu1	
 憿	giu1	
 澆	giu1	
 驕	giu1	
@@ -6110,7 +6070,6 @@ import_tables:
 蹻	giu2	
 轎	giu2	
 鱎	giu2	
-蹻	giu2	
 㰾	giu3	
 叫	giu3	
 嘂	giu3	
@@ -6155,7 +6114,6 @@ import_tables:
 匷	goek3	
 屩	goek3	
 腳	goek3	
-屩	goek3	
 㳾	goeng1	
 㹔	goeng1	
 䕬	goeng1	
@@ -6285,10 +6243,8 @@ import_tables:
 岡	gong1	
 崗	gong1	
 扛	gong1	
-掆	gong1	
 摃	gong1	
 杠	gong1	
-棡	gong1	
 江	gong1	
 犅	gong1	
 瓨	gong1	
@@ -6594,7 +6550,6 @@ import_tables:
 龔	gung1	
 𢓁	gung1	
 𢣁	gung1	
-魟	gung1	
 㤨	gung2	
 㧬	gung2	
 㭟	gung2	
@@ -6904,7 +6859,6 @@ import_tables:
 隟	gwik1	
 馘	gwik1	
 鵙	gwik1	
-鶪	gwik1	
 䮐	gwing1	
 坰	gwing1	
 扃	gwing1	
@@ -6928,7 +6882,6 @@ import_tables:
 炯	gwing2	
 煚	gwing2	
 熲	gwing2	
-絅	gwing2	
 苘	gwing2	
 褧	gwing2	
 詗	gwing2	
@@ -7043,7 +6996,6 @@ import_tables:
 睠	gyun3	
 絭	gyun3	
 絹	gyun3	
-縳	gyun3	
 罥	gyun3	
 讂	gyun3	
 鄄	gyun3	
@@ -7160,7 +7112,6 @@ import_tables:
 楁	haak6	
 嵌	haam1	
 㘚	haam2	
-㘚	haam2	
 㦿	haam2	
 㺖	haam2	
 闞	haam2	
@@ -7168,7 +7119,6 @@ import_tables:
 㒈	haam3	
 㘚	haam3	
 㘕	haam3	
-㘚	haam3	
 㦑	haam3	
 喊	haam3	
 闞	haam3	
@@ -7965,7 +7915,6 @@ import_tables:
 鴞	hiu1	
 𡏭	hiu1	
 𢿣	hiu1	
-蹻	hiu1	
 䥵	hiu2	
 曉	hiu2	
 𣇈	hiu2	
@@ -8183,7 +8132,6 @@ import_tables:
 鶾	hon6	
 𨌺	hon6	
 𨯪	hon6	
-駻	hon6	
 㑌	hong1	
 㰠	hong1	
 㱂	hong1	
@@ -8440,7 +8388,6 @@ import_tables:
 𤄏	hung4	
 𨩅	hung4	
 𪃡	hung4	
-魟	hung4	
 㶹	hung6	
 哄	hung6	
 澒	hung6	
@@ -8677,7 +8624,6 @@ import_tables:
 絪	jan1	
 茵	jan1	
 裀	jan1	
-訢	jan1	
 諲	jan1	
 銦	jan1	
 闉	jan1	
@@ -8707,7 +8653,6 @@ import_tables:
 蘟	jan2	
 讔	jan2	
 隱	jan2	
-蘟	jan2	
 㒚	jan3	
 㡥	jan3	
 㥼	jan3	
@@ -8715,7 +8660,6 @@ import_tables:
 鮣	jan3	
 印	jan3	
 茚	jan3	
-鮣	jan3	
 㝙	jan4	
 人	jan4	
 仁	jan4	
@@ -9277,12 +9221,10 @@ import_tables:
 𤪦	ji4	
 𦲀	ji4	
 𩓧	ji4	
-訑	ji4	
 㕥	ji5	
 㠯	ji5	
 㩘	ji5	
 㰝	ji5	
-䋙	ji5	
 䋙	ji5	
 以	ji5	
 佁	ji5	
@@ -9379,7 +9321,6 @@ import_tables:
 㶠	jik6	
 䄩	jik6	
 䋚	jik6	
-䋚	jik6	
 䓈	jik6	
 䘝	jik6	
 䣧	jik6	
@@ -9474,7 +9415,6 @@ import_tables:
 黤	jim2	
 黭	jim2	
 黶	jim2	
-龑	jim2	
 𥀬	jim2	
 𦝡	jim2	
 㛪	jim3	
@@ -9605,7 +9545,6 @@ import_tables:
 曣	jin3	
 烻	jin3	
 燕	jin3	
-讌	jin3	
 酀	jin3	
 醼	jin3	
 驠	jin3	
@@ -9659,7 +9598,6 @@ import_tables:
 蚿	jin4	
 蜒	jin4	
 言	jin4	
-賢	jin4	
 郔	jin4	
 鋋	jin4	
 𤉷	jin4	
@@ -9726,7 +9664,6 @@ import_tables:
 瀴	jing1	
 瑛	jing1	
 瓔	jing1	
-纓	jing1	
 膺	jing1	
 英	jing1	
 蘡	jing1	
@@ -10154,7 +10091,6 @@ import_tables:
 蛘	joeng5	
 養	joeng5	
 𡒶	joeng5	
-𡒶	joeng5	
 𣞼	joeng5	
 𨦪	joeng5	
 㨾	joeng6	
@@ -10452,7 +10388,6 @@ import_tables:
 䰻	jyu4	
 䱷	jyu4	
 䲆	jyu4	
-䱷	jyu4	
 与	jyu4	
 予	jyu4	
 于	jyu4	
@@ -10817,7 +10752,6 @@ import_tables:
 瓀	jyun5	
 礝	jyun5	
 耎	jyun5	
-薳	jyun5	
 軟	jyun5	
 輭	jyun5	
 遠	jyun5	
@@ -10896,7 +10830,6 @@ import_tables:
 𧑐	jyut6	
 𧞄	jyut6	
 𨬓	jyut6	
-軏	jyut6	
 㤉	kaa1	
 䶗	kaa1	
 佧	kaa1	
@@ -11270,7 +11203,6 @@ import_tables:
 鮈	keoi1	
 𢳉	keoi1	
 𥕥	keoi1	
-𥕥	keoi1	
 蟝	keoi2	
 㜹	keoi4	
 㣄	keoi4	
@@ -11555,7 +11487,6 @@ import_tables:
 殨	kui2	
 䈐	kui2	
 䙡	kui2	
-䙡	kui2	
 䭝	kui2	
 䯤	kui2	
 儈	kui2	
@@ -11566,7 +11497,6 @@ import_tables:
 旝	kui2	
 會	kui2	
 檜	kui2	
-殨	kui2	
 潰	kui2	
 澮	kui2	
 獪	kui2	
@@ -11600,7 +11530,6 @@ import_tables:
 笻	kung4	
 筇	kung4	
 芎	kung4	
-藭	kung4	
 蛩	kung4	
 跫	kung4	
 邛	kung4	
@@ -11644,7 +11573,6 @@ import_tables:
 嘳	kwaai3	
 擓	kwaai5	
 㨤	kwaai5	
-擓	kwaai5	
 𡁸	kwaak1	
 𡃈	kwaak1	
 𡃈	kwaak3	
@@ -11877,7 +11805,6 @@ import_tables:
 鈌	kyut3	
 鐍	kyut3	
 鐝	kyut3	
-钁	kyut3	
 闋	kyut3	
 闕	kyut3	
 駃	kyut3	
@@ -11886,8 +11813,6 @@ import_tables:
 鴃	kyut3	
 鷢	kyut3	
 轣	kyut3	
-鐍	kyut3	
-鴃	kyut3	
 啦	la1	
 嘞	la3	
 嘑	la4	
@@ -11974,7 +11899,6 @@ import_tables:
 𩖞	laam4	
 擥	laam5	
 㩜	laam5	
-㩜	laam5	
 㰖	laam5	
 䈒	laam5	
 䊖	laam5	
@@ -12008,7 +11932,6 @@ import_tables:
 斕	laan4	
 欄	laan4	
 瀾	laan4	
-灡	laan4	
 籣	laan4	
 蘭	laan4	
 襴	laan4	
@@ -12185,7 +12108,6 @@ import_tables:
 冧	lam3	
 㝝	lam4	
 䋻	lam4	
-䋻	lam4	
 䫐	lam4	
 林	lam4	
 淋	lam4	
@@ -12233,8 +12155,6 @@ import_tables:
 鴗	lap6	
 𠈔	lap6	
 𨚪	lap6	
-𩶘	lap6	
-鴗	lap6	
 甩	lat1	
 𢫫	lat1	
 㺏	lau1	
@@ -12275,7 +12195,6 @@ import_tables:
 寠	lau4	
 嵧	lau4	
 廔	lau4	
-慺	lau4	
 懰	lau4	
 摎	lau4	
 摟	lau4	
@@ -12290,7 +12209,6 @@ import_tables:
 琉	lau4	
 留	lau4	
 瘤	lau4	
-瞜	lau4	
 硫	lau4	
 窶	lau4	
 耬	lau4	
@@ -12377,7 +12295,6 @@ import_tables:
 䊍	lei4	
 䋥	lei4	
 䋱	lei4	
-䍦	lei4	
 䍦	lei4	
 䔆	lei4	
 䔧	lei4	
@@ -12584,7 +12501,6 @@ import_tables:
 鑸	leoi5	
 閭	leoi5	
 鸓	leoi5	
-㜢	leoi5	
 𥚃	leoi5	
 𧃒	leoi5	
 㔣	leoi6	
@@ -12758,7 +12674,6 @@ import_tables:
 嚦	lik6	
 壢	lik6	
 屴	lik6	
-擽	lik6	
 曆	lik6	
 朸	lik6	
 歷	lik6	
@@ -12816,7 +12731,6 @@ import_tables:
 㱨	lim5	
 䌞	lim5	
 䭑	lim5	
-歛	lim5	
 溓	lim5	
 羷	lim5	
 臉	lim5	
@@ -12983,12 +12897,10 @@ import_tables:
 𤦫	ling4	
 𤪥	ling4	
 𤫊	ling4	
-𤫩	ling4	
 𥩔	ling4	
 𧭈	ling4	
 𨤍	ling4	
 𩆜	ling4	
-軨	ling4	
 䔭	ling5	
 岭	ling5	
 嶺	ling5	
@@ -13050,7 +12962,6 @@ import_tables:
 迾	lit6	
 颲	lit6	
 鮤	lit6	
-鴷	lit6	
 𣵀	lit6	
 𦶣	lit6	
 𨑬	lit6	
@@ -13095,7 +13006,6 @@ import_tables:
 繚	liu4	
 翏	liu4	
 聊	liu4	
-膋	liu4	
 膫	liu4	
 蟟	liu4	
 豂	liu4	
@@ -13155,7 +13065,6 @@ import_tables:
 㼈	lo4	
 㽋	lo4	
 䊨	lo4	
-儸	lo4	
 囖	lo4	
 撋	lo4	
 欏	lo4	
@@ -13218,7 +13127,6 @@ import_tables:
 良	loeng4	
 莨	loeng4	
 踉	loeng4	
-輬	loeng4	
 輬	loeng4	
 量	loeng4	
 𣸑	loeng4	
@@ -13371,7 +13279,6 @@ import_tables:
 浪	long6	
 蒗	long6	
 𧚅	long6	
-嚕	lou1	
 嚕	lou1	
 撈	lou1	
 黸	lou1	
@@ -13716,7 +13623,6 @@ import_tables:
 傌	maa6	
 㾺	maa6	
 䧞	maa6	
-傌	maa6	
 榪	maa6	
 禡	maa6	
 罵	maa6	
@@ -14862,7 +14768,6 @@ import_tables:
 鐃	naau4	
 𥑪	naau4	
 𥒚	naau4	
-譊	naau4	
 撓	naau5	
 淖	naau6	
 臑	naau6	
@@ -14882,7 +14787,6 @@ import_tables:
 𥻚	nam1	
 諗	nam2	
 惗	nam2	
-䋻	nam4	
 䋻	nam4	
 淰	nam4	
 腍	nam4	
@@ -15240,7 +15144,6 @@ import_tables:
 麑	ngai4	
 齯	ngai4	
 𤊓	ngai4	
-輗	ngai4	
 㠖	ngai5	
 䃬	ngai5	
 䉝	ngai5	
@@ -15470,7 +15373,6 @@ import_tables:
 皚	ngoi4	
 騃	ngoi4	
 𨹦	ngoi4	
-騃	ngoi4	
 㕌	ngoi6	
 外	ngoi6	
 硋	ngoi6	
@@ -15520,7 +15422,6 @@ import_tables:
 銨	ngon1	
 𤇼	ngon1	
 𤥃	ngon1	
-𩣑	ngon1	
 洝	ngon3	
 㸩	ngon4	
 㟁	ngon6	
@@ -15686,7 +15587,6 @@ import_tables:
 𡩋	ning4	
 𤪥	ning4	
 𧭈	ning4	
-鸋	ning4	
 䔭	ning5	
 㣷	ning6	
 㲌	ning6	
@@ -15707,7 +15607,6 @@ import_tables:
 䌜	nip6	
 䌰	nip6	
 䎎	nip6	
-䯀	nip6	
 䯀	nip6	
 䳖	nip6	
 捏	nip6	
@@ -15831,7 +15730,6 @@ import_tables:
 㛴	nou5	
 㺁	nou5	
 䜀	nou5	
-䜀	nou5	
 努	nou5	
 堖	nou5	
 弩	nou5	
@@ -15850,7 +15748,6 @@ import_tables:
 朒	nuk6	
 衂	nuk6	
 衄	nuk6	
-燶	nung1	
 燶	nung1	
 𪒬	nung1	
 㺜	nung4	
@@ -16038,7 +15935,6 @@ import_tables:
 帊	paa3	
 怕	paa3	
 袙	paa3	
-䎱	paa4	
 䎱	paa4	
 扒	paa4	
 掱	paa4	
@@ -16589,7 +16485,6 @@ import_tables:
 痡	pou1	
 鋪	pou1	
 鯆	pou1	
-鯆	pou1	
 圃	pou2	
 普	pou2	
 氆	pou2	
@@ -16736,7 +16631,6 @@ import_tables:
 䪬	put3	
 潑	put3	
 醱	put3	
-鏺	put3	
 𣸍	put3	
 㠺	saa1	
 㲚	saa1	
@@ -16782,7 +16676,6 @@ import_tables:
 蓰	saai2	
 諰	saai2	
 蹝	saai2	
-諰	saai2	
 㬠	saai3	
 䵘	saai3	
 哂	saai3	
@@ -16809,11 +16702,9 @@ import_tables:
 仨	saam1	
 叁	saam1	
 參	saam1	
-幓	saam1	
 弎	saam1	
 摻	saam1	
 毿	saam1	
-穇	saam1	
 縿	saam1	
 芟	saam1	
 衫	saam1	
@@ -17031,7 +16922,6 @@ import_tables:
 𣿯	sam1	
 𤀻	sam1	
 𨨥	sam1	
-綝	sam1	
 㕴	sam2	
 㧲	sam2	
 㰂	sam2	
@@ -17244,7 +17134,6 @@ import_tables:
 滫	sau2	
 狩	sau2	
 瞍	sau2	
-籔	sau2	
 艏	sau2	
 艘	sau2	
 藪	sau2	
@@ -17255,7 +17144,6 @@ import_tables:
 𢯱	sau2	
 𥈟	sau2	
 𩠐	sau2	
-謏	sau2	
 㛢	sau3	
 嗽	sau3	
 宿	sau3	
@@ -17292,7 +17180,6 @@ import_tables:
 賒	se1	
 㕐	se2	
 㝍	se2	
-䥱	se2	
 䥱	se2	
 䬷	se2	
 寫	se2	
@@ -17385,7 +17272,6 @@ import_tables:
 𤟠	seoi1	
 𦷪	seoi1	
 㑯	seoi2	
-㑯	seoi2	
 㝽	seoi2	
 䅡	seoi2	
 䭉	seoi2	
@@ -17473,7 +17359,6 @@ import_tables:
 粹	seoi6	
 絮	seoi6	
 繐	seoi6	
-繸	seoi6	
 脺	seoi6	
 膵	seoi6	
 萃	seoi6	
@@ -17715,7 +17600,6 @@ import_tables:
 𩅰	si1	
 𪀔	si1	
 𪆓	si1	
-鰤	si1	
 㕜	si2	
 㹬	si2	
 䂠	si2	
@@ -17727,7 +17611,6 @@ import_tables:
 死	si2	
 諰	si2	
 𧳅	si2	
-諰	si2	
 㣈	si3	
 㳏	si3	
 䛈	si3	
@@ -17930,7 +17813,6 @@ import_tables:
 䡪	sin3	
 䤼	sin3	
 䥇	sin3	
-䥇	sin3	
 鐥	sin3	
 䨘	sin3	
 䨷	sin3	
@@ -17944,7 +17826,6 @@ import_tables:
 輤	sin3	
 釤	sin3	
 鏾	sin3	
-鐥	sin3	
 霰	sin3	
 騸	sin3	
 𠜎	sin3	
@@ -18046,7 +17927,6 @@ import_tables:
 溗	sing4	
 澠	sing4	
 盛	sing4	
-繩	sing4	
 誠	sing4	
 郕	sing4	
 鋮	sing4	
@@ -18125,7 +18005,6 @@ import_tables:
 𥜽	sit3	
 𧵳	sit6	
 舌	sit6	
-𧵳	sit6	
 㩋	siu1	
 㲖	siu1	
 㲵	siu1	
@@ -18147,7 +18026,6 @@ import_tables:
 綃	siu1	
 翛	siu1	
 萷	siu1	
-蕭	siu1	
 蛸	siu1	
 蠨	siu1	
 踃	siu1	
@@ -18164,7 +18042,6 @@ import_tables:
 少	siu2	
 筱	siu2	
 篠	siu2	
-謏	siu2	
 謏	siu2	
 㔅	siu3	
 㗛	siu3	
@@ -18245,7 +18122,6 @@ import_tables:
 𠿬	soe4	
 𡄽	soe4	
 䁻	soek3	
-䁻	soek3	
 削	soek3	
 勺	soek3	
 杓	soek3	
@@ -18283,7 +18159,6 @@ import_tables:
 艭	soeng1	
 葙	soeng1	
 蔏	soeng1	
-襄	soeng1	
 觴	soeng1	
 謪	soeng1	
 鑲	soeng1	
@@ -18401,7 +18276,6 @@ import_tables:
 嫂	sou2	
 掃	sou2	
 數	sou2	
-籔	sou2	
 𦺋	sou2	
 㕖	sou3	
 㨞	sou3	
@@ -18455,7 +18329,6 @@ import_tables:
 宿	suk1	
 橚	suk1	
 洬	suk1	
-潚	suk1	
 焂	suk1	
 粟	suk1	
 縮	suk1	
@@ -18504,7 +18377,6 @@ import_tables:
 𥯆	sung1	
 㩳	sung2	
 㨦	sung2	
-㩳	sung2	
 傱	sung2	
 嵷	sung2	
 悚	sung2	
@@ -18830,7 +18702,6 @@ import_tables:
 澾	taat3	
 㿹	taat3	
 撻	taat3	
-澾	taat3	
 羍	taat3	
 趿	taat3	
 躂	taat3	
@@ -18913,8 +18784,6 @@ import_tables:
 鷤	tai4	
 𧡰	tai4	
 𪂿	tai4	
-騠	tai4	
-鶗	tai4	
 㼵	tai5	
 䑯	tai5	
 娣	tai5	
@@ -18955,7 +18824,6 @@ import_tables:
 邆	tang4	
 騰	tang4	
 驣	tang4	
-鰧	tang4	
 𥸎	tang4	
 𧬸	tang4	
 𠸊	tap1	
@@ -19021,8 +18889,6 @@ import_tables:
 頹	teoi4	
 魋	teoi4	
 𠒺	teoi4	
-穨	teoi4	
-隤	teoi4	
 䝎	teon1	
 䵎	teon1	
 啍	teon1	
@@ -19099,7 +18965,6 @@ import_tables:
 淟	tin2	
 腆	tin2	
 覥	tin2	
-靦	tin2	
 瑱	tin3	
 睼	tin3	
 㧂	tin4	
@@ -19646,7 +19511,6 @@ import_tables:
 咼	waa1	
 哇	waa1	
 唲	waa1	
-喎	waa1	
 嘩	waa1	
 娃	waa1	
 挖	waa1	5%
@@ -19659,7 +19523,6 @@ import_tables:
 窪	waa1	
 蛙	waa1	
 譁	waa1	
-騧	waa1	
 鼃	waa1	
 𤱰	waa1	
 𪎩	waa1	
@@ -19668,7 +19531,6 @@ import_tables:
 搲	waa2	
 畫	waa2	
 𢱑	waa2	
-㠏	waa4	
 㠏	waa4	
 㦊	waa4	
 㭉	waa4	
@@ -19726,7 +19588,6 @@ import_tables:
 蘾	waai6	
 㕷	waak1	
 㗲	waak1	
-㗲	waak1	
 劃	waak6	
 㖪	waak6	
 㦎	waak6	
@@ -19737,7 +19598,6 @@ import_tables:
 䬉	waak6	
 䰥	waak6	
 剨	waak6	
-劃	waak6	
 嫿	waak6	
 惑	waak6	
 或	waak6	
@@ -19779,7 +19639,6 @@ import_tables:
 闤	waan4	
 頑	waan4	
 鬟	waan4	
-䴉	waan4	
 𡦃	waan4	
 挽	waan5	
 輓	waan5	
@@ -19870,7 +19729,6 @@ import_tables:
 萎	wai2	
 蒍	wai2	0%
 蔿	wai2	
-薳	wai2	
 虫	wai2	
 虺	wai2	
 蜼	wai2	
@@ -20293,7 +20151,6 @@ import_tables:
 媧	wo1	
 涹	wo1	
 渦	wo1	
-濄	wo1	
 猧	wo1	
 窠	wo1	
 窩	wo1	
@@ -20353,7 +20210,6 @@ import_tables:
 㳹	wong2	
 㴏	wong2	
 枉	wong2	
-瀇	wong2	
 𠶖	wong2	
 㞷	wong4	
 㾮	wong4	
@@ -20398,7 +20254,6 @@ import_tables:
 鷬	wong4	
 黃	wong4	
 𤾗	wong4	
-餭	wong4	
 往	wong5	
 䌙	wong6	
 旺	wong6	
@@ -20861,7 +20716,6 @@ import_tables:
 𠲜	zaang1	
 𧶄	zaang1	
 䦛	zaang3	
-䦛	zaang3	
 諍	zaang3	
 䂻	zaang6	
 掙	zaang6	
@@ -20956,7 +20810,6 @@ import_tables:
 䪣	zai1	
 䮺	zai1	
 劑	zai1	
-擠	zai1	
 櫅	zai1	
 虀	zai1	
 躋	zai1	
@@ -21253,9 +21106,7 @@ import_tables:
 酒	zau2	
 鯞	zau2	
 㑳	zau3	
-㑳	zau3	
 㔿	zau3	
-㥮	zau3	
 㥮	zau3	
 㩆	zau3	
 㼙	zau3	
@@ -21273,7 +21124,6 @@ import_tables:
 晝	zau3	
 甃	zau3	
 皺	zau3	
-縐	zau3	
 㔌	zau6	
 㠇	zau6	
 㵵	zau6	
@@ -21460,7 +21310,6 @@ import_tables:
 辠	zeoi6	
 鱮	zeoi6	
 𨣦	zeoi6	
-鱮	zeoi6	
 㡒	zeon1	
 㰉	zeon1	
 䘒	zeon1	
@@ -21495,7 +21344,6 @@ import_tables:
 綧	zeon2	
 藎	zeon2	
 賮	zeon2	
-贐	zeon2	
 隼	zeon2	
 㑺	zeon3	
 㕙	zeon3	
@@ -21584,7 +21432,6 @@ import_tables:
 㽻	zi1	
 䅔	zi1	
 䊷	zi1	
-䊷	zi1	
 䎩	zi1	
 䓡	zi1	
 䓩	zi1	
@@ -21662,7 +21509,6 @@ import_tables:
 𤦧	zi1	
 𦔒	zi1	
 𪗋	zi1	
-鳷	zi1	
 㕄	zi2	
 㜽	zi2	
 㞨	zi2	
@@ -21970,7 +21816,6 @@ import_tables:
 䙁	zin1	
 䱳	zin1	
 帴	zin1	
-戔	zin1	
 揃	zin1	
 旃	zin1	
 栴	zin1	
@@ -21980,7 +21825,6 @@ import_tables:
 濺	zin1	
 煎	zin1	
 牋	zin1	
-箋	zin1	
 籛	zin1	
 緘	zin1	
 羶	zin1	
@@ -22049,7 +21893,6 @@ import_tables:
 薦	zin3	
 諓	zin3	
 顫	zin3	
-餞	zin3	
 𩥇	zin3	
 纏	zin6	
 賤	zin6	
@@ -22088,7 +21931,6 @@ import_tables:
 貞	zing1	
 遉	zing1	
 鉦	zing1	
-鶄	zing1	
 鼱	zing1	
 𢘫	zing1	
 𤉋	zing1	
@@ -22116,7 +21958,6 @@ import_tables:
 𤴓	zing3	
 𦭒	zing3	
 㣏	zing6	
-䝼	zing6	
 䝼	zing6	
 凈	zing6	
 凊	zing6	
@@ -22328,7 +22169,6 @@ import_tables:
 著	zoek3	
 謶	zoek3	
 酌	zoek3	
-鐯	zoek3	
 雀	zoek3	
 鵲	zoek3	
 𥫩	zoek3	
@@ -22551,7 +22391,6 @@ import_tables:
 䙯	zuk1	
 䟉	zuk1	
 䥮	zuk1	
-劚	zuk1	
 哫	zuk1	
 囑	zuk1	
 屬	zuk1	
@@ -22683,7 +22522,6 @@ import_tables:
 傯	zung2	
 尰	zung2	
 摠	zung2	
-摠	zung2	
 熜	zung2	
 种	zung2	
 種	zung2	
@@ -22805,7 +22643,6 @@ import_tables:
 磚	zyun1	
 篿	zyun1	
 耑	zyun1	
-膞	zyun1	
 蟤	zyun1	
 躦	zyun1	
 遵	zyun1	
@@ -28756,7 +28593,6 @@ import_tables:
 本科生	bun2 fo1 sang1
 本拉登	bun2 laai1 dang1
 本來	bun2 loi4
-本來	bun2 loi4
 本來面目	bun2 loi4 min6 muk6
 本壘	bun2 leoi5
 本壘打	bun2 leoi5 daa2
@@ -30522,7 +30358,6 @@ import_tables:
 賓仔	ban1 zai2
 賓至如歸	ban1 zi3 jyu4 gwai1
 賓治	ban1 zi6
-賓舟	ban1 zau1
 賓州	ban1 zau1
 賓州仔	ban1 zau1 zai2
 賓周	ban1 zau1
@@ -31263,7 +31098,6 @@ import_tables:
 菠菜豆腐	bo1 coi3 dau6 fu6
 菠蘿包	bo1 lo4 baau1
 菠蘿	bo1 lo4
-菠蘿包	bo1 lo4 baau1
 菠蘿彈	bo1 lo4 daan6
 菠蘿彈	bo1 lo4 daan2
 菠蘿釘	bo1 lo4 deng1
@@ -33520,7 +33354,6 @@ import_tables:
 彩色	coi2 sik1
 彩色電視	coi2 sik1 din6 si6
 彩數	coi2 sou3
-彩數	coi2 sou3
 彩塑	coi2 sou3
 彩陶	coi2 tou4
 彩陶文化	coi2 tou4 man4 faa3
@@ -33548,7 +33381,6 @@ import_tables:
 踩車	caai2 ce1
 踩嚫條尾	caai2 can3 tiu4 mei5
 踩錯腳	caai2 co3 goek3
-踩單車	caai2 daan1 ce1
 踩單車	caai2 daan1 ce1
 踩單車	caai1 daan1 ce1
 踩單車	jaai2 daan1 ce1
@@ -33679,7 +33511,6 @@ import_tables:
 參觀團體	caam1 gun1 tyun4 tai2
 參觀者	caam1 gun1 ze2
 參劾	caam1 hat6
-參加	caam1 gaa1
 參加者	caam1 gaa1 ze2
 參見	caam1 gin3
 參軍	caam1 gwan1
@@ -36161,7 +35992,6 @@ import_tables:
 潮州柑	ciu4 zau1 gam1
 潮州花燈	ciu4 zau1 faa1 dang1
 潮州話	ciu4 zau1 waa2
-潮州話	ciu4 zau1 waa2
 潮州市	ciu4 zau1 si5
 潮州水晶包	ciu4 zau1 seoi2 zing1 baau1
 潮州音樂	ciu4 zau1 jam1 ngok6
@@ -37564,7 +37394,6 @@ import_tables:
 癡人說夢	ci1 jan4 syut3 mung6
 癡傻	ci1 so4
 癡騃	ci1 ngoi4
-癡線	ci1 sin3
 癡綫	ci1 sin3
 癡想	ci1 soeng2
 癡笑	ci1 siu3
@@ -42774,7 +42603,6 @@ import_tables:
 大粒嘢	daai6 nap1 je5
 大粒嘢	daai6 lap1 je5
 大麗花	daai6 lai6 faa1
-大瀝	daai6 lik6
 大連	daai6 lin4
 大連理工大學	daai6 lin4 lei5 gung1 daai6 hok6
 大連市	daai6 lin4 si5
@@ -43103,7 +42931,6 @@ import_tables:
 大赦	daai6 se3
 大赦國際	daai6 se3 gwok3 zai3
 大神	daai6 san4
-大諗頭	daai6 nam2 tau4
 大嬸	daai6 sam2
 大聲	daai6 seng1
 大聲	daai6 sing1
@@ -60746,7 +60573,6 @@ import_tables:
 唂咕	guk1 gu2
 唂咕	guk1 gu1
 唂精上腦	guk1 zing1 soeng5 nou5
-唂精上腦	guk1 zing1 soeng5 nou5
 唂氣	guk1 hei3
 辜負	gu1 fu6
 辜鴻銘	gu1 hung4 ming4
@@ -65320,7 +65146,6 @@ import_tables:
 好不容易	hou2 bat1 jung4 ji6
 好彩	hou2 coi2
 好彩數	hou2 coi2 sou3
-好彩數	hou2 coi2 sou3
 好殘	hou2 caan4
 好嘈	hou2 cou4
 好長遠	hou2 coeng4 jyun5
@@ -65498,7 +65323,6 @@ import_tables:
 好命水	hou2 meng6 seoi2
 好耐	hou2 noi6
 好耐好耐之前	hou2 noi6 hou2 noi6 zi1 cin4
-好耐冇見	hou2 noi6 mou5 gin3
 好耐冇見	hou2 noi6 mou5 gin3
 好男不跟女鬥	hou2 naam4 bat1 gan1 neoi5 dau3
 好嫩	hou2 nyun6
@@ -72021,13 +71845,11 @@ import_tables:
 禍胎	wo6 toi1
 禍心	wo6 sam1
 禍棗災梨	wo6 zou2 zoi1 lei4
-㗲㗲	waak1 waak1
 膕動脈	gwok3 dung6 mak6
 膕肌	gwok3 gei1
 膕靜脈	gwok3 zing6 mak6
 膕旁腱肌	gwok3 pong4 gin3 gei1
 膕繩肌	gwok3 sing4 gei1
-膕窩	gwok3 wo1
 膕窩囊腫	gwok3 wo1 nong4 zung2
 霍比特人	fok3 bei2 dak6 jan4
 霍布斯	fok3 bou3 si1
@@ -79977,7 +79799,6 @@ import_tables:
 精校本	zing1 gaau3 bun2
 精心	zing1 sam1
 精選	zing1 syun2
-精選	zing1 syun2
 精選輯	zing1 syun2 cap1
 精研	zing1 jin4
 精液	zing1 jik6
@@ -83275,7 +83096,6 @@ import_tables:
 看慣	hon3 gwaan3
 看好	hon3 hou2
 看護	hon1 wu6
-看護	hon1 wu6
 看花眼	hon3 faa1 ngaan5
 看家	hon1 gaa1
 看見	hon3 gin3
@@ -85204,7 +85024,6 @@ import_tables:
 褲衩	fu3 caa3
 褲穿窿	fu3 cyun1 lung4
 褲帶	fu3 daai2
-褲帶	fu3 daai2
 褲袋	fu3 doi2
 褲襠	fu3 dong1
 褲骨	fu3 gwat1
@@ -85889,7 +85708,6 @@ import_tables:
 闊口拿扒	fut3 hau2 naa4 paa4
 闊老	fut3 lou5
 闊佬	fut3 lou2
-闊佬懶理	fut3 lou2 laan5 lei5
 闊佬懶理	fut3 lou2 laan5 lei5
 闊咧啡	fut3 le4 fe4
 闊落	fut3 lok6
@@ -90945,7 +90763,6 @@ import_tables:
 凜遵	lam5 zeon1
 吝盡	leon6 zeon6
 吝嗇	leon6 sik1
-吝嗇	leon6 sik1
 吝嗇鬼	leon6 sik1 gwai2
 吝惜	leon6 sik1
 藺相如	leon6 soeng1 jyu4
@@ -95974,7 +95791,6 @@ import_tables:
 冇紋冇路	mou5 man4 mou5 lou6
 冇問題	mou5 man6 tai4
 冇問	mou5 man6
-冇問題	mou5 man6 tai4
 冇搵	mou5 wan2
 冇戲睇	mou5 hei3 tai2
 冇下扒	mou5 haa6 paa4
@@ -103411,7 +103227,6 @@ import_tables:
 爬牆	paa4 coeng4
 爬山	paa4 saan1
 爬山單車	paa4 saan1 daan1 ce1
-爬山單車	paa4 saan1 daan1 ce1
 爬山虎	paa4 saan1 fu2
 爬山涉水	paa4 saan1 sip3 seoi2
 爬上	paa4 soeng5
@@ -107258,7 +107073,6 @@ import_tables:
 騎馬者	ke4 maa5 ze2
 騎呢	ke4 le4
 騎呢	ke4 ne4
-騎呢拐	ke4 le4 gwaai2
 騎呢怪	ke4 le4 gwaai3
 騎呢怪	ke4 le4 gwaai2
 騎呢位	ke4 le4 wai2
@@ -110272,7 +110086,6 @@ import_tables:
 傾國傾城	king1 gwok3 king1 sing4
 傾計	king1 gai3
 傾計	king1 gai2
-傾偈	king1 gai2
 傾家	king1 gaa1
 傾家蕩產	king1 gaa1 dong6 caan2
 傾角	king1 gok3
@@ -117927,7 +117740,6 @@ import_tables:
 攝護腺腫大	sip3 wu6 sin3 zung2 daai6
 攝錄	sip3 luk6
 攝錄機	sip3 luk6 gei1
-攝青鬼	sip3 ceng1 gwai2
 攝親	sip3 can1
 攝取	sip3 ceoi2
 攝入	sip3 jap6
@@ -118634,7 +118446,6 @@ import_tables:
 諗埋一便	nam2 maai4 jat1 bin6
 諗埋一面	nam2 maai4 jat1 min6
 諗明	nam2 ming4
-諗起	nam2 hei2
 諗竅	nam2 kiu2
 諗清楚	nam2 cing1 co2
 諗清諗楚	nam2 cing1 nam2 co2
@@ -118643,7 +118454,6 @@ import_tables:
 諗縮數	nam2 suk1 sou3
 諗通	lam2 tung1
 諗通	nam2 tung1
-諗頭	nam2 tau4
 諗唔到	nam2 m4 dou2
 諗唔掂	nam2 m4 dim6
 諗唔過	nam2 m4 gwo3
@@ -118654,7 +118464,6 @@ import_tables:
 諗嘢唔經大腦	nam2 je5 m4 ging1 daai6 nou5
 諗真	nam2 zan1
 諗真啲	nam2 zan1 di1
-諗住	nam2 zyu6
 諗住	lam2 zyu6
 諗咗下	nam2 zo2 haa5
 審案	sam2 on3
@@ -127669,7 +127478,6 @@ import_tables:
 台球桌	toi2 kau4 coek3
 台山	toi4 saan1
 台山話	toi4 saan1 waa2
-台山話	toi4 saan1 waa2
 台山市	toi4 saan1 si5
 台商	toi4 soeng1
 台上三分鐘，台下十年功	toi4 soeng6 saam1 fan1 zung1 toi4 haa6 sap6 nin4 gung1
@@ -128297,7 +128105,6 @@ import_tables:
 坦陳	taan2 can4
 坦誠	taan2 sing4
 坦承	taan2 sing4
-坦誠	taan2 sing4
 坦誠相見	taan2 sing4 soeng1 gin3
 坦蕩	taan2 dong6
 坦噶尼喀	taan2 gaa1 nei4 kaa3
@@ -136800,7 +136607,6 @@ import_tables:
 蝸旋	wo1 syun4
 蝸蜒	wo1 jin4
 我愛你	ngo5 oi3 nei5
-我愛你	ngo5 oi3 nei5
 我輩	ngo5 bui3
 我比	ngo5 bei2
 我比你	ngo5 bei2 nei5
@@ -137423,7 +137229,6 @@ import_tables:
 唔該嗮	m4 goi1 saai3
 唔該晒	m4 goi1 saai3
 唔敢	m4 gam2
-唔敢當	m4 gam2 dong1
 唔敢當	m4 gam2 dong1
 唔趕	m4 gon2
 唔高興	m4 gou1 hing3
@@ -140222,7 +140027,6 @@ import_tables:
 係囉	hai6 lo1
 係咪	hai6 mai6
 係咪先	hai6 mai6 sin1
-係咪先	hai6 mai6 sin1
 係咪真嘅	hai6 mai6 zan1 ge3
 係咩	hai6 me1
 係哶	hai6 me1
@@ -142161,7 +141965,6 @@ import_tables:
 香骨	hoeng1 gwat1
 香瓜	hoeng1 gwaa1
 香瓜汁	hoeng1 gwaa1 zap1
-香閨	hoeng1 gwai1
 香閨	hoeng1 gwai1
 香桂	hoeng1 gwai3
 香汗淋漓	hoeng1 hon6 lam4 lei4
@@ -144277,7 +144080,6 @@ import_tables:
 心野	sam1 je5
 心儀	sam1 ji4
 心疑	sam1 ji4
-心儀	sam1 ji4
 心悒	sam1 ngap1
 心悒	sam1 jap1
 心意	sam1 ji3
@@ -145722,7 +145524,6 @@ import_tables:
 休養所	jau1 joeng5 so2
 休養	jau1 joeng5
 休養生息	jau1 joeng5 sang1 sik1
-休養所	jau1 joeng5 so2
 休伊特	jau1 ji1 dak6
 休漁期	jau1 jyu4 kei4
 休戰	jau1 zin3
@@ -148015,7 +147816,6 @@ import_tables:
 腌肉	jim1 juk6
 腌魚	jip3 jyu2
 腌臢	ap1 zap1
-腌臢	jim1 zim1
 腌臢	jim1 zim1
 腌製	jip3 zai3
 湮沒	jin1 mut6
@@ -165233,7 +165033,6 @@ import_tables:
 終戰日	zung1 zin3 jat6
 終之	zung1 zi1
 終止	zung1 zi2
-鍾意	zung1 ji3
 鍾愛	zung1 oi3
 鍾村	zung1 cyun1
 鍾點房	zung1 dim2 fong4
@@ -165247,7 +165046,6 @@ import_tables:
 鍾唔鍾意	zung1 m4 zung1 ji3
 鍾欣桐	zung1 jan1 tung4
 鍾繇	zung1 jiu4
-鍾意	zung1 ji3
 鍾意點就點	zung1 ji3 dim2 zau6 dim2
 鍾意佢	zung1 ji3 keoi5
 鍾子期	zung1 zi2 kei4

--- a/jyut6ping3.dict.yaml
+++ b/jyut6ping3.dict.yaml
@@ -178,7 +178,7 @@ import_tables:
 凹	aau3	
 坳	aau3	
 垇	aau3	
-嶴	aau3	
+岙	aau3	
 拗	aau3	
 詏	aau3	
 靿	aau3	
@@ -2683,7 +2683,7 @@ import_tables:
 采	coi3	
 𡤐	coi3	
 𡧳	coi3	
-第	coi4	
+㐧	coi4	
 㒲	coi4	
 䴭	coi4	
 才	coi4	
@@ -2967,7 +2967,7 @@ import_tables:
 𢊍	cyu4	
 𨆼	cyu4	
 㑏	cyu5	
-宁	cyu5	
+㝉	cyu5	
 㿾	cyu5	
 䇠	cyu5	
 䇡	cyu5	
@@ -5827,7 +5827,7 @@ import_tables:
 𤉸	geoi1	
 𩤅	geoi1	
 㩮	geoi2	
-舉	geoi2	
+㪯	geoi2	
 䄔	geoi2	
 䅓	geoi2	
 䶚	geoi2	
@@ -7910,7 +7910,7 @@ import_tables:
 㾜	hip3	
 䁋	hip3	
 䏩	hip3	
-脇	hip3	
+䏮	hip3	
 勰	hip3	
 協	hip3	
 嗋	hip3	
@@ -13000,7 +13000,7 @@ import_tables:
 睖	ling6	
 踜	ling6	
 𤀑	ling6	
-𨋢	lip1	
+䢂	lip1	
 𨋢	lip1	
 㬯	lip6	
 㯿	lip6	
@@ -14441,7 +14441,7 @@ import_tables:
 㟐	mong5	
 㬒	mong5	
 䁳	mong5	
-綱	mong5	
+䋄	mong5	
 䋞	mong5	
 䒎	mong5	
 䒽	mong5	
@@ -14483,7 +14483,7 @@ import_tables:
 摸	mou4	
 摹	mou4	
 旄	mou4	
-無	mou4	
+无	mou4	
 模	mou4	
 橆	mou4	
 毋	mou4	
@@ -16015,7 +16015,7 @@ import_tables:
 噢	ou3	
 墺	ou3	
 奧	ou3	
-嶴	ou3	
+岙	ou3	
 嶴	ou3	
 懊	ou3	
 澳	ou3	
@@ -17413,7 +17413,7 @@ import_tables:
 税	seoi3	0%
 繀	seoi3	
 蛻	seoi3	
-蛻	seoi3	0%
+蜕	seoi3	0%
 裞	seoi3	
 說	seoi3	
 説	seoi3	0%
@@ -19006,7 +19006,7 @@ import_tables:
 毻	teoi3	
 煺	teoi3	
 蛻	teoi3	
-蛻	teoi3	0%
+蜕	teoi3	0%
 退	teoi3	
 駾	teoi3	
 㢈	teoi4	
@@ -20020,28 +20020,28 @@ import_tables:
 㬈	wan1	
 㼔	wan1	
 奫	wan1	
-榲	wan1	0%
+榅	wan1	0%
 榲	wan1	
 殟	wan1	
-氳	wan1	0%
+氲	wan1	0%
 氳	wan1	
 温	wan1	0%
 溫	wan1	
-熅	wan1	0%
+煴	wan1	0%
 熅	wan1	
 瘟	wan1	
 緼	wan1	0%
 縕	wan1	
 蒀	wan1	0%
 蒕	wan1	
-薀	wan1	
+蕰	wan1	
 薀	wan1	
 蝹	wan1	
 豱	wan1	
 贇	wan1	
 輼	wan1	0%
 轀	wan1	
-轀	wan1	
+辒	wan1	
 頵	wan1	
 馧	wan1	
 鰛	wan1	0%
@@ -20202,7 +20202,7 @@ import_tables:
 嗢	wat1	
 尉	wat1	
 屈	wat1	
-榲	wat1	0%
+榅	wat1	0%
 榲	wat1	
 灪	wat1	
 煀	wat1	
@@ -20949,7 +20949,7 @@ import_tables:
 䂑	zai1	
 䜞	zai1	
 䝴	zai1	
-躋	zai1	
+䠁	zai1	
 䪠	zai1	
 䪡	zai1	
 䪢	zai1	
@@ -20970,7 +20970,7 @@ import_tables:
 囝	zai2	
 濟	zai2	
 㝂	zai3	
-濟	zai3	
+㴉	zai3	
 䇽	zai3	
 䎺	zai3	
 䨖	zai3	
@@ -165177,7 +165177,7 @@ import_tables:
 盅頭飯	zung1 tau2 faan6
 盅頭飯	zung1 tau4 faan6
 盅仔飯	zung1 zai2 faan6
-鈡意	zung1 ji3
+鍾意	zung1 ji3
 衷腸	cung1 coeng4
 衷誠	cung1 sing4
 衷情	cung1 cing4

--- a/jyut6ping3.dict.yaml
+++ b/jyut6ping3.dict.yaml
@@ -62,7 +62,7 @@ import_tables:
 瘂	aa2	
 㚳	aa3	
 㰳	aa3	
-䅉	aa3	
+稏	aa3	
 䢝	aa3	
 亞	aa3	
 俹	aa3	
@@ -80,7 +80,7 @@ import_tables:
 𦩒	aa3	
 𩤃	aa3	
 䄰	aa4	
-䥺	aa4	
+釾	aa4	
 呀	aa4	
 齖	aa4	
 雅	aa5	
@@ -135,7 +135,7 @@ import_tables:
 㗴	aan4	
 㘖	aan4	
 𪆒	aan6	
-䓨	aang1	
+罃	aang1	
 甇	aang1	
 甖	aang1	
 罌	aang1	
@@ -178,7 +178,7 @@ import_tables:
 凹	aau3	
 坳	aau3	
 垇	aau3	
-岙	aau3	
+嶴	aau3	
 拗	aau3	
 詏	aau3	
 靿	aau3	
@@ -295,7 +295,7 @@ import_tables:
 㹜	an4	
 㹞	an4	
 䇵	an4	
-䜣	an4	
+訢	an4	
 䴦	an4	
 齦	an4	
 㴈	an6	
@@ -324,7 +324,7 @@ import_tables:
 㽾	at6	
 䑢	at6	
 䖌	at6	
-䢀	at6	
+𨊰	at6	
 䪲	at6	
 扤	at6	
 疙	at6	
@@ -404,7 +404,7 @@ import_tables:
 跁	baa6	
 拜	baai1	
 掰	baai1	
-䙓	baai2	
+襬	baai2	
 捭	baai2	
 擺	baai2	
 襬	baai2	
@@ -538,7 +538,7 @@ import_tables:
 泵	bam1	
 㟗	ban1	
 㯽	ban1	
-㺍	ban1	
+獱	ban1	
 㻞	ban1	
 䚔	ban1	
 䧬	ban1	
@@ -809,7 +809,7 @@ import_tables:
 壁	bik3	
 璧	bik3	
 𠁆	bik6	
-㺍	bin1	
+獱	bin1	
 䟍	bin1	
 煸	bin1	
 猵	bin1	
@@ -1058,7 +1058,7 @@ import_tables:
 㨍	bong1	
 㿶	bong1	
 䢶	bong1	
-䦁	bong1	
+𨧜	bong1	
 䩷	bong1	
 幫	bong1	
 梆	bong1	
@@ -1094,8 +1094,8 @@ import_tables:
 逋	bou1	
 鈽	bou1	
 餔	bou1	
-𫐓	bou1	
-𫚙	bou1	
+輮	bou1	
+鯆	bou1	
 㙅	bou2	
 㙛	bou2	
 㻄	bou2	
@@ -1139,7 +1139,7 @@ import_tables:
 布	bou3	
 怖	bou3	
 餔	bou3	
-𫐓	bou3	
+輮	bou3	
 㫧	bou6	
 㬧	bou6	
 㲒	bou6	
@@ -1162,7 +1162,7 @@ import_tables:
 虣	bou6	
 部	bou6	
 𣭚	bou6	
-𫐓	bou6	
+輮	bou6	
 㮎	bui1	
 杯	bui1	
 桮	bui1	
@@ -1189,7 +1189,7 @@ import_tables:
 鋇	bui3	
 𧵔	bui3	
 𨩈	bui3	
-𠀾	bui5	
+𠁞	bui5	
 㧩	bui6	
 㹀	bui6	
 䊃	bui6	
@@ -1363,7 +1363,7 @@ import_tables:
 瘥	caai3	
 蠆	caai3	
 袃	caai3	
-㑪	caai4	
+儕	caai4	
 㾹	caai4	
 䓱	caai4	
 儕	caai4	
@@ -1380,7 +1380,7 @@ import_tables:
 㩞	caak3	
 㿭	caak3	
 䁤	caak3	
-䇲	caak3	
+筴	caak3	
 䊂	caak3	
 䜺	caak3	
 䶦	caak3	
@@ -1402,7 +1402,7 @@ import_tables:
 賊	caak6	
 㕘	caam1	
 㜗	caam1	
-㟥	caam1	
+嵾	caam1	
 㠁	caam1	
 㰫	caam1	
 䟃	caam1	
@@ -1415,7 +1415,7 @@ import_tables:
 𠻝	caam1	
 㦧	caam2	
 㿊	caam2	
-䅟	caam2	
+穇	caam2	
 噆	caam2	
 慘	caam2	
 憯	caam2	
@@ -1638,7 +1638,7 @@ import_tables:
 譖	cam3	
 讖	cam3	
 𩂈	cam3	
-㚯	cam4	
+㜄	cam4	
 㜄	cam4	
 㜦	cam4	
 䒞	cam4	
@@ -1746,9 +1746,9 @@ import_tables:
 𠀁	cat1	
 𨳍	cat6	
 𫵱	cat6	
-㑇	cau1	
 㑳	cau1	
-㤘	cau1	
+㑳	cau1	
+㥮	cau1	
 㥮	cau1	
 㨨	cau1	
 㩅	cau1	
@@ -1756,10 +1756,10 @@ import_tables:
 䀺	cau1	
 䆋	cau1	
 䋺	cau1	
-䌷	cau1	
+紬	cau1	
 䐐	cau1	
 䨂	cau1	
-䲡	cau1	
+鰌	cau1	
 妯	cau1	
 抽	cau1	
 搊	cau1	
@@ -1803,15 +1803,15 @@ import_tables:
 輳	cau3	
 𩡗	cau3	
 㘜	cau4	
-㤽	cau4	
+懤	cau4	
 㥢	cau4	
 㦞	cau4	
 㷕	cau4	
 㿧	cau4	
 䌧	cau4	
-䌷	cau4	
+紬	cau4	
 䎿	cau4	
-䓓	cau4	
+薵	cau4	
 䯾	cau4	
 䲖	cau4	
 仇	cau4	
@@ -1923,13 +1923,13 @@ import_tables:
 趡	ceoi2	
 𧍒	ceoi2	
 㯔	ceoi3	
-㳃	ceoi3	
+淬	ceoi3	
 䁦	ceoi3	
 䃀	ceoi3	
 䄟	ceoi3	
 䕜	ceoi3	
 䦟	ceoi3	
-䦷	ceoi3	
+䦟	ceoi3	
 䴝	ceoi3	
 倅	ceoi3	
 吹	ceoi3	
@@ -1981,7 +1981,7 @@ import_tables:
 㫩	ceon1	
 㻐	ceon1	
 䡅	ceon1	
-䲠	ceon1	
+鰆	ceon1	
 堾	ceon1	
 旾	ceon1	
 春	ceon1	
@@ -2065,7 +2065,7 @@ import_tables:
 鴟	ci1	
 黐	ci1	
 齝	ci1	
-𫄨	ci1	
+絺	ci1	
 㢁	ci2	
 㢋	ci2	
 㶴	ci2	
@@ -2249,7 +2249,7 @@ import_tables:
 𥄎	cik1	
 𦭐	cik1	
 𪆵	cik1	
-𫛶	cik1	
+鶒	cik1	
 刺	cik3	
 蚇	cik3	
 赤	cik3	
@@ -2400,7 +2400,7 @@ import_tables:
 䄇	cing4	
 䇸	cing4	
 䝼	cing4	
-䞍	cing4	
+䝼	cing4	
 呈	cing4	
 埕	cing4	
 情	cing4	
@@ -2656,7 +2656,7 @@ import_tables:
 𢒑	coeng4	
 啋	coi1	
 㥒	coi2	
-䌽	coi2	
+綵	coi2	
 䐆	coi2	
 䣋	coi2	
 寀	coi2	
@@ -2683,7 +2683,7 @@ import_tables:
 采	coi3	
 𡤐	coi3	
 𡧳	coi3	
-㐧	coi4	
+第	coi4	
 㒲	coi4	
 䴭	coi4	
 才	coi4	
@@ -2700,7 +2700,7 @@ import_tables:
 䄝	cong1	
 䚎	cong1	
 䱽	cong1	
-䲝	cong1	
+䱽	cong1	
 倉	cong1	
 傖	cong1	
 凔	cong1	
@@ -2845,7 +2845,7 @@ import_tables:
 𦌊	cuk1	
 𨀂	cuk1	
 𫂙	cuk1	
-𫗧	cuk1	
+餗	cuk1	
 㜡	cung1	
 㤝	cung1	
 㥖	cung1	
@@ -2901,7 +2901,7 @@ import_tables:
 𦿞	cung1	
 𧘂	cung1	
 𪻐	cung1	
-𫓩	cung1	
+鏦	cung1	
 冢	cung2	
 塚	cung2	
 寵	cung2	
@@ -2967,7 +2967,7 @@ import_tables:
 𢊍	cyu4	
 𨆼	cyu4	
 㑏	cyu5	
-㝉	cyu5	
+宁	cyu5	
 㿾	cyu5	
 䇠	cyu5	
 䇡	cyu5	
@@ -3089,9 +3089,9 @@ import_tables:
 䚟	daai2	
 傣	daai2	
 歹	daai2	
-㛿	daai3	
+𡠹	daai3	
 㯂	daai3	
-䙊	daai3	
+𧜵	daai3	
 帶	daai3	
 戴	daai3	
 艜	daai3	
@@ -3109,7 +3109,7 @@ import_tables:
 大	daai6	
 汏	daai6	
 軑	daai6	
-轪	daai6	
+軑	daai6	
 釱	daai6	
 𠯈	daai6	
 咑	daak1	
@@ -3175,7 +3175,7 @@ import_tables:
 𨭐	daan1	
 蛋	daan2	
 㡺	daan3	
-䜥	daan3	
+𧩙	daan3	
 旦	daan3	
 狚	daan3	
 癉	daan3	
@@ -3258,7 +3258,7 @@ import_tables:
 𧞅	daat6	
 㓳	dai1	
 㫝	dai1	
-䃅	dai1	
+磾	dai1	
 䍕	dai1	
 䐎	dai1	
 䧑	dai1	
@@ -3289,7 +3289,7 @@ import_tables:
 邸	dai2	
 阺	dai2	
 骶	dai2	
-䗖	dai3	
+螮	dai3	
 䟡	dai3	
 䩘	dai3	
 䩚	dai3	
@@ -3526,8 +3526,8 @@ import_tables:
 㟋	deoi6	
 㠚	deoi6	
 㬣	deoi6	
-㳔	deoi6	
-䌼	deoi6	
+濧	deoi6	
+綐	deoi6	
 䨴	deoi6	
 䬈	deoi6	
 䯟	deoi6	
@@ -4025,8 +4025,8 @@ import_tables:
 裻	duk1	
 𡰪	duk1	
 𢽴	duk1	
-㱩	duk6	
-㸿	duk6	
+殰	duk6	
+犢	duk6	
 㾄	duk6	
 䓯	duk6	
 䢱	duk6	
@@ -4053,7 +4053,7 @@ import_tables:
 髑	duk6	
 黷	duk6	
 𦢌	duk6	
-㑈	dung1	
+倲	dung1	
 㚵	dung1	
 㫡	dung1	
 㲇	dung1	
@@ -4275,7 +4275,7 @@ import_tables:
 髮	faat3	
 𠵽	faat3	
 𧬋	faat3	
-㧑	fai1	
+撝	fai1	
 㩣	fai1	
 㫎	fai1	
 㹆	fai1	
@@ -4302,7 +4302,7 @@ import_tables:
 疿	fai2	
 痱	fai2	
 㵒	fai3	
-㾱	fai3	
+癈	fai3	
 䉬	fai3	
 䑔	fai3	
 䕠	fai3	
@@ -4387,7 +4387,7 @@ import_tables:
 𤑛	fan1	
 𤦈	fan1	
 𨧼	fan1	
-𫄸	fan1	
+纁	fan1	
 㥹	fan2	
 粉	fan2	
 㱵	fan3	
@@ -4650,7 +4650,7 @@ import_tables:
 㺢	fok3	
 䁨	fok3	
 䂄	fok3	
-䦆	fok3	
+钁	fok3	
 彏	fok3	
 戄	fok3	
 攉	fok3	
@@ -4803,7 +4803,7 @@ import_tables:
 骷	fu1	
 鳺	fu1	
 麩	fu1	
-𫓧	fu1	
+鈇	fu1	
 㓡	fu2	
 㕮	fu2	
 䇢	fu2	
@@ -4952,7 +4952,7 @@ import_tables:
 𡟼	fui3	
 㙏	fuk1	
 䋹	fuk1	
-䌿	fuk1	
+䋹	fuk1	
 䕎	fuk1	
 䨱	fuk1	
 䫝	fuk1	
@@ -5019,7 +5019,7 @@ import_tables:
 款	fun2	
 盥	fun2	
 窾	fun2	
-㐽	fung1	
+偑	fung1	
 㒥	fung1	
 㕫	fung1	
 㛔	fung1	
@@ -5252,7 +5252,7 @@ import_tables:
 𠺝	gaak3	
 㮭	gaam1	
 䌠	gaam1	
-䛓	gaam1	
+譼	gaam1	
 䶠	gaam1	
 䶢	gaam1	
 尲	gaam1	
@@ -5328,7 +5328,7 @@ import_tables:
 㰰	gaap3	
 㿓	gaap3	
 䀫	gaap3	
-䇲	gaap3	
+筴	gaap3	
 䕛	gaap3	
 䩡	gaap3	
 唊	gaap3	
@@ -5370,7 +5370,7 @@ import_tables:
 㶀	gaau1	
 䍊	gaau1	
 䢒	gaau1	
-䴔	gaau1	
+鵁	gaau1	
 交	gaau1	
 峧	gaau1	
 教	gaau1	
@@ -5614,9 +5614,9 @@ import_tables:
 趌	gat6	
 趷	gat6	
 㞗	gau1	
-䦰	gau1	
+𨷺	gau1	
 䧱	gau1	
-䰗	gau1	
+鬮	gau1	
 䲥	gau1	
 䲫	gau1	
 勼	gau1	
@@ -5700,7 +5700,7 @@ import_tables:
 㫷	gei1	
 㼄	gei1	
 䇫	gei1	
-䘛	gei1	
+𧝞	gei1	
 䟇	gei1	
 䟚	gei1	
 䥓	gei1	
@@ -5827,7 +5827,7 @@ import_tables:
 𤉸	geoi1	
 𩤅	geoi1	
 㩮	geoi2	
-㪯	geoi2	
+舉	geoi2	
 䄔	geoi2	
 䅓	geoi2	
 䶚	geoi2	
@@ -5940,7 +5940,7 @@ import_tables:
 劒	gim3	
 儉	gim6	
 㡉	gin1	
-㭴	gin1	
+樫	gin1	
 㸫	gin1	
 䋗	gin1	
 䌑	gin1	
@@ -6085,7 +6085,7 @@ import_tables:
 𡩣	git6	
 𤌴	git6	
 𦵴	git6	
-㤭	giu1	
+憍	giu1	
 䮦	giu1	
 儌	giu1	
 嬌	giu1	
@@ -6110,7 +6110,7 @@ import_tables:
 蹻	giu2	
 轎	giu2	
 鱎	giu2	
-𫏋	giu2	
+蹻	giu2	
 㰾	giu3	
 叫	giu3	
 嘂	giu3	
@@ -6155,7 +6155,7 @@ import_tables:
 匷	goek3	
 屩	goek3	
 腳	goek3	
-𪨗	goek3	
+屩	goek3	
 㳾	goeng1	
 㹔	goeng1	
 䕬	goeng1	
@@ -6270,9 +6270,9 @@ import_tables:
 㓻	gong1	
 㟠	gong1	
 㟵	gong1	
-㧏	gong1	
+掆	gong1	
 㭃	gong1	
-㭎	gong1	
+棡	gong1	
 㼚	gong1	
 䌉	gong1	
 䚗	gong1	
@@ -6568,7 +6568,7 @@ import_tables:
 㓛	gung1	
 㣉	gung1	
 㫒	gung1	
-䂵	gung1	
+碽	gung1	
 䢼	gung1	
 䣏	gung1	
 䰸	gung1	
@@ -6594,7 +6594,7 @@ import_tables:
 龔	gung1	
 𢓁	gung1	
 𢣁	gung1	
-𫚉	gung1	
+魟	gung1	
 㤨	gung2	
 㧬	gung2	
 㭟	gung2	
@@ -6883,7 +6883,7 @@ import_tables:
 䦗	gwik1	
 䧍	gwik1	
 䱛	gwik1	
-䴗	gwik1	
+鶪	gwik1	
 侐	gwik1	
 殈	gwik1	
 洫	gwik1	
@@ -6915,7 +6915,7 @@ import_tables:
 㯋	gwing2	
 㷗	gwing2	
 㷡	gwing2	
-䌹	gwing2	
+絅	gwing2	
 䔛	gwing2	
 䢛	gwing2	
 冏	gwing2	
@@ -7025,7 +7025,7 @@ import_tables:
 㪻	gyun3	
 㯞	gyun3	
 䄅	gyun3	
-䌸	gyun3	
+縳	gyun3	
 䖭	gyun3	
 䡓	gyun3	
 䣺	gyun3	
@@ -7159,14 +7159,14 @@ import_tables:
 䞦	haak6	
 楁	haak6	
 嵌	haam1	
-㘎	haam2	
+㘚	haam2	
 㘚	haam2	
 㦿	haam2	
 㺖	haam2	
 闞	haam2	
 鬫	haam2	
 㒈	haam3	
-㘎	haam3	
+㘚	haam3	
 㘕	haam3	
 㘚	haam3	
 㦑	haam3	
@@ -7640,7 +7640,7 @@ import_tables:
 䐅	hei1	
 䒊	hei1	
 䖷	hei1	
-䜣	hei1	
+訢	hei1	
 䤈	hei1	
 䫏	hei1	
 俙	hei1	
@@ -7910,7 +7910,7 @@ import_tables:
 㾜	hip3	
 䁋	hip3	
 䏩	hip3	
-䏮	hip3	
+脇	hip3	
 勰	hip3	
 協	hip3	
 嗋	hip3	
@@ -7965,7 +7965,7 @@ import_tables:
 鴞	hiu1	
 𡏭	hiu1	
 𢿣	hiu1	
-𫏋	hiu1	
+蹻	hiu1	
 䥵	hiu2	
 曉	hiu2	
 𣇈	hiu2	
@@ -8152,7 +8152,7 @@ import_tables:
 悍	hon5	
 捍	hon5	
 旱	hon5	
-𫘣	hon5	
+駻	hon5	
 㢨	hon6	
 㪋	hon6	
 㲦	hon6	
@@ -8183,7 +8183,7 @@ import_tables:
 鶾	hon6	
 𨌺	hon6	
 𨯪	hon6	
-𫘣	hon6	
+駻	hon6	
 㑌	hong1	
 㰠	hong1	
 㱂	hong1	
@@ -8440,7 +8440,7 @@ import_tables:
 𤄏	hung4	
 𨩅	hung4	
 𪃡	hung4	
-𫚉	hung4	
+魟	hung4	
 㶹	hung6	
 哄	hung6	
 澒	hung6	
@@ -8652,7 +8652,7 @@ import_tables:
 㶏	jan1	
 䄄	jan1	
 䓰	jan1	
-䜣	jan1	
+訢	jan1	
 䧣	jan1	
 因	jan1	
 垔	jan1	
@@ -8707,12 +8707,12 @@ import_tables:
 蘟	jan2	
 讔	jan2	
 隱	jan2	
-𦻕	jan2	
+蘟	jan2	
 㒚	jan3	
 㡥	jan3	
 㥼	jan3	
 㾙	jan3	
-䲟	jan3	
+鮣	jan3	
 印	jan3	
 茚	jan3	
 鮣	jan3	
@@ -9000,7 +9000,7 @@ import_tables:
 𧙗	jau6	
 㭨	je4	
 䓉	je4	
-䥺	je4	
+釾	je4	
 倻	je4	
 揶	je4	
 擨	je4	
@@ -9277,13 +9277,13 @@ import_tables:
 𤪦	ji4	
 𦲀	ji4	
 𩓧	ji4	
-𫍙	ji4	
+訑	ji4	
 㕥	ji5	
 㠯	ji5	
 㩘	ji5	
 㰝	ji5	
 䋙	ji5	
-䌺	ji5	
+䋙	ji5	
 以	ji5	
 佁	ji5	
 儗	ji5	
@@ -9379,7 +9379,7 @@ import_tables:
 㶠	jik6	
 䄩	jik6	
 䋚	jik6	
-䌻	jik6	
+䋚	jik6	
 䓈	jik6	
 䘝	jik6	
 䣧	jik6	
@@ -9457,7 +9457,7 @@ import_tables:
 䄋	jim2	
 䣍	jim2	
 䲓	jim2	
-䶮	jim2	
+龑	jim2	
 厴	jim2	
 噞	jim2	
 奄	jim2	
@@ -9518,7 +9518,7 @@ import_tables:
 䎦	jim5	
 䒣	jim5	
 䤡	jim5	
-䶮	jim5	
+龑	jim5	
 儼	jim5	
 冉	jim5	
 剡	jim5	
@@ -9594,7 +9594,7 @@ import_tables:
 㬫	jin3	
 㰽	jin3	
 㷼	jin3	
-䜩	jin3	
+讌	jin3	
 䞁	jin3	
 䴏	jin3	
 傿	jin3	
@@ -9633,7 +9633,7 @@ import_tables:
 䕼	jin4	
 䖄	jin4	
 䗡	jin4	
-䝨	jin4	
+賢	jin4	
 䢥	jin4	
 䳿	jin4	
 伭	jin4	
@@ -9709,7 +9709,7 @@ import_tables:
 𩃀	jin6	
 䁐	jing1	
 䊔	jing1	
-䋝	jing1	
+纓	jing1	
 䣐	jing1	
 䦫	jing1	
 䧹	jing1	
@@ -10153,7 +10153,7 @@ import_tables:
 癢	joeng5	
 蛘	joeng5	
 養	joeng5	
-𡏆	joeng5	
+𡒶	joeng5	
 𡒶	joeng5	
 𣞼	joeng5	
 𨦪	joeng5	
@@ -10452,7 +10452,7 @@ import_tables:
 䰻	jyu4	
 䱷	jyu4	
 䲆	jyu4	
-䲣	jyu4	
+䱷	jyu4	
 与	jyu4	
 予	jyu4	
 于	jyu4	
@@ -10807,7 +10807,7 @@ import_tables:
 㮕	jyun5	
 㼱	jyun5	
 䎡	jyun5	
-䓕	jyun5	
+薳	jyun5	
 䓴	jyun5	
 䞂	jyun5	
 䩙	jyun5	
@@ -10863,7 +10863,7 @@ import_tables:
 䋖	jyut6	
 䟠	jyut6	
 䡇	jyut6	
-䢁	jyut6	
+𨊸	jyut6	
 䢖	jyut6	
 䤦	jyut6	
 乙	jyut6	
@@ -10896,7 +10896,7 @@ import_tables:
 𧑐	jyut6	
 𧞄	jyut6	
 𨬓	jyut6	
-𫐄	jyut6	
+軏	jyut6	
 㤉	kaa1	
 䶗	kaa1	
 佧	kaa1	
@@ -11269,7 +11269,7 @@ import_tables:
 魼	keoi1	
 鮈	keoi1	
 𢳉	keoi1	
-𥐰	keoi1	
+𥕥	keoi1	
 𥕥	keoi1	
 蟝	keoi2	
 㜹	keoi4	
@@ -11552,9 +11552,9 @@ import_tables:
 鵟	kong4	
 㗄	ku1	
 箍	ku1	
-㱮	kui2	
+殨	kui2	
 䈐	kui2	
-䙌	kui2	
+䙡	kui2	
 䙡	kui2	
 䭝	kui2	
 䯤	kui2	
@@ -11594,7 +11594,7 @@ import_tables:
 㮪	kung4	
 䅃	kung4	
 䊄	kung4	
-䓖	kung4	
+藭	kung4	
 穹	kung4	
 窮	kung4	
 笻	kung4	
@@ -11642,7 +11642,7 @@ import_tables:
 跨	kwaa3	
 骻	kwaa3	
 嘳	kwaai3	
-㧟	kwaai5	
+擓	kwaai5	
 㨤	kwaai5	
 擓	kwaai5	
 𡁸	kwaak1	
@@ -11842,7 +11842,7 @@ import_tables:
 䀗	kyut3	
 䍳	kyut3	
 䏐	kyut3	
-䦆	kyut3	
+钁	kyut3	
 䦼	kyut3	
 䳏	kyut3	
 劂	kyut3	
@@ -11885,9 +11885,9 @@ import_tables:
 鴂	kyut3	
 鴃	kyut3	
 鷢	kyut3	
-𫐆	kyut3	
-𫔎	kyut3	
-𫛞	kyut3	
+轣	kyut3	
+鐍	kyut3	
+鴃	kyut3	
 啦	la1	
 嘞	la3	
 嘑	la4	
@@ -11942,7 +11942,7 @@ import_tables:
 勒	laak6	
 砳	laak6	
 肋	laak6	
-㧛	laam2	
+擥	laam2	
 㩜	laam2	
 攬	laam2	
 杬	laam2	
@@ -11954,7 +11954,7 @@ import_tables:
 㲯	laam4	
 㽖	laam4	
 䆾	laam4	
-䍀	laam4	
+繿	laam4	
 䛁	laam4	
 䰐	laam4	
 嚂	laam4	
@@ -11972,8 +11972,8 @@ import_tables:
 𦮗	laam4	
 𨩇	laam4	
 𩖞	laam4	
-㧛	laam5	
-㨫	laam5	
+擥	laam5	
+㩜	laam5	
 㩜	laam5	
 㰖	laam5	
 䈒	laam5	
@@ -12000,7 +12000,7 @@ import_tables:
 躝	laan1	
 𢦂	laan2	
 㘓	laan4	
-㳕	laan4	
+灡	laan4	
 䦨	laan4	
 䪍	laan4	
 幱	laan4	
@@ -12058,7 +12058,7 @@ import_tables:
 邋	laap6	
 鑞	laap6	
 𠺶	laap6	
-𫚭	laap6	
+鱲	laap6	
 瘌	laat3	
 㻋	laat6	
 㻝	laat6	
@@ -12185,7 +12185,7 @@ import_tables:
 冧	lam3	
 㝝	lam4	
 䋻	lam4	
-䌾	lam4	
+䋻	lam4	
 䫐	lam4	
 林	lam4	
 淋	lam4	
@@ -12227,18 +12227,18 @@ import_tables:
 粒	lap1	
 苙	lap1	
 㵫	lap6	
-䲞	lap6	
+𩶘	lap6	
 搚	lap6	
 立	lap6	
 鴗	lap6	
 𠈔	lap6	
 𨚪	lap6	
 𩶘	lap6	
-𫁡	lap6	
+鴗	lap6	
 甩	lat1	
 𢫫	lat1	
 㺏	lau1	
-䁖	lau1	
+瞜	lau1	
 嘍	lau1	
 摟	lau1	
 褸	lau1	
@@ -12248,11 +12248,11 @@ import_tables:
 㐬	lau4	
 㖻	lau4	
 㡞	lau4	
-㥪	lau4	
+慺	lau4	
 㳅	lau4	
 㺏	lau4	
 㽞	lau4	
-䁖	lau4	
+瞜	lau4	
 䅹	lau4	
 䉧	lau4	
 䖻	lau4	
@@ -12377,7 +12377,7 @@ import_tables:
 䊍	lei4	
 䋥	lei4	
 䋱	lei4	
-䍠	lei4	
+䍦	lei4	
 䍦	lei4	
 䔆	lei4	
 䔧	lei4	
@@ -12584,7 +12584,7 @@ import_tables:
 鑸	leoi5	
 閭	leoi5	
 鸓	leoi5	
-𡞱	leoi5	
+㜢	leoi5	
 𥚃	leoi5	
 𧃒	leoi5	
 㔣	leoi6	
@@ -12618,7 +12618,7 @@ import_tables:
 鑢	leoi6	
 類	leoi6	
 𧭜	leoi6	
-𩔗	leoi6	
+䫫	leoi6	
 𩸭	leoi6	
 㖥	leon1	
 噒	leon1	
@@ -12736,7 +12736,7 @@ import_tables:
 㔏	lik6	
 㠣	lik6	
 㥾	lik6	
-㧰	lik6	
+擽	lik6	
 㬏	lik6	
 㱹	lik6	
 㷴	lik6	
@@ -12809,10 +12809,10 @@ import_tables:
 𢅳	lim4	
 𤅄	lim4	
 㜤	lim5	
-㪘	lim5	
+斂	lim5	
 㯬	lim5	
 㰈	lim5	
-㰸	lim5	
+歛	lim5	
 㱨	lim5	
 䌞	lim5	
 䭑	lim5	
@@ -12895,7 +12895,7 @@ import_tables:
 㲆	ling4	
 㲰	ling4	
 㸳	ling4	
-㻏	ling4	
+𤫩	ling4	
 㾉	ling4	
 䄥	ling4	
 䆨	ling4	
@@ -12988,7 +12988,7 @@ import_tables:
 𧭈	ling4	
 𨤍	ling4	
 𩆜	ling4	
-𫐉	ling4	
+軨	ling4	
 䔭	ling5	
 岭	ling5	
 嶺	ling5	
@@ -13000,7 +13000,7 @@ import_tables:
 睖	ling6	
 踜	ling6	
 𤀑	ling6	
-䢂	lip1	
+𨋢	lip1	
 𨋢	lip1	
 㬯	lip6	
 㯿	lip6	
@@ -13023,7 +13023,7 @@ import_tables:
 𣀳	lip6	
 𤢪	lip6	
 𦘒	lip6	
-𫚭	lip6	
+鱲	lip6	
 結	lit3	
 纈	lit3	
 𤹐	lit3	
@@ -13034,7 +13034,7 @@ import_tables:
 䅀	lit6	
 䋑	lit6	
 䮋	lit6	
-䴕	lit6	
+鴷	lit6	
 冽	lit6	
 列	lit6	
 咧	lit6	
@@ -13068,7 +13068,7 @@ import_tables:
 㞠	liu4	
 㵳	liu4	
 㺐	liu4	
-䒿	liu4	
+膋	liu4	
 䜍	liu4	
 䜮	liu4	
 䨅	liu4	
@@ -13150,7 +13150,7 @@ import_tables:
 咯	lo3	
 摞	lo3	
 𤓓	lo3	
-㑩	lo4	
+儸	lo4	
 㰙	lo4	
 㼈	lo4	
 㽋	lo4	
@@ -13205,7 +13205,7 @@ import_tables:
 啢	loeng2	
 㹁	loeng4	
 䣼	loeng4	
-䭪	loeng4	
+𩞯	loeng4	
 俍	loeng4	
 墚	loeng4	
 梁	loeng4	
@@ -13219,7 +13219,7 @@ import_tables:
 莨	loeng4	
 踉	loeng4	
 輬	loeng4	
-辌	loeng4	
+輬	loeng4	
 量	loeng4	
 𣸑	loeng4	
 𨫟	loeng4	
@@ -13371,7 +13371,7 @@ import_tables:
 浪	long6	
 蒗	long6	
 𧚅	long6	
-噜	lou1	
+嚕	lou1	
 嚕	lou1	
 撈	lou1	
 黸	lou1	
@@ -13432,7 +13432,7 @@ import_tables:
 𠫂	lou4	
 𤏪	lou4	
 𤩂	lou4	
-𦛨	lou4	
+朥	lou4	
 𨥬	lou4	
 㔪	lou5	
 㛴	lou5	
@@ -13563,7 +13563,7 @@ import_tables:
 𤀼	luk6	
 𤊒	luk6	
 𩣱	luk6	
-㶶	lung1	
+燶	lung1	
 窿	lung1	
 𥥅	lung1	
 㚅	lung4	
@@ -13713,7 +13713,7 @@ import_tables:
 鎷	maa5	
 馬	maa5	
 𥡗	maa5	
-㐷	maa6	
+傌	maa6	
 㾺	maa6	
 䧞	maa6	
 傌	maa6	
@@ -14441,7 +14441,7 @@ import_tables:
 㟐	mong5	
 㬒	mong5	
 䁳	mong5	
-䋄	mong5	
+綱	mong5	
 䋞	mong5	
 䒎	mong5	
 䒽	mong5	
@@ -14483,7 +14483,7 @@ import_tables:
 摸	mou4	
 摹	mou4	
 旄	mou4	
-无	mou4	
+無	mou4	
 模	mou4	
 橆	mou4	
 毋	mou4	
@@ -14862,7 +14862,7 @@ import_tables:
 鐃	naau4	
 𥑪	naau4	
 𥒚	naau4	
-𫍢	naau4	
+譊	naau4	
 撓	naau5	
 淖	naau6	
 臑	naau6	
@@ -14883,7 +14883,7 @@ import_tables:
 諗	nam2	
 惗	nam2	
 䋻	nam4	
-䌾	nam4	
+䋻	nam4	
 淰	nam4	
 腍	nam4	
 䄒	nam5	
@@ -15053,7 +15053,7 @@ import_tables:
 阿	ngaa2	
 㚳	ngaa3	
 㰳	ngaa3	
-䅉	ngaa3	
+稏	ngaa3	
 埡	ngaa3	
 掗	ngaa3	
 阿	ngaa3	
@@ -15064,7 +15064,7 @@ import_tables:
 𩤃	ngaa3	
 㧎	ngaa4	
 䄰	ngaa4	
-䥺	ngaa4	
+釾	ngaa4	
 伢	ngaa4	
 岈	ngaa4	
 牙	ngaa4	
@@ -15240,7 +15240,7 @@ import_tables:
 麑	ngai4	
 齯	ngai4	
 𤊓	ngai4	
-𫐐	ngai4	
+輗	ngai4	
 㠖	ngai5	
 䃬	ngai5	
 䉝	ngai5	
@@ -15325,7 +15325,7 @@ import_tables:
 㹜	ngan4	
 㹞	ngan4	
 䇵	ngan4	
-䜣	ngan4	
+訢	ngan4	
 䴦	ngan4	
 嚚	ngan4	
 圁	ngan4	
@@ -15363,7 +15363,7 @@ import_tables:
 㽾	ngat6	
 䑢	ngat6	
 䖌	ngat6	
-䢀	ngat6	
+𨊰	ngat6	
 䪲	ngat6	
 仡	ngat6	
 兀	ngat6	
@@ -15470,7 +15470,7 @@ import_tables:
 皚	ngoi4	
 騃	ngoi4	
 𨹦	ngoi4	
-𫘤	ngoi4	
+騃	ngoi4	
 㕌	ngoi6	
 外	ngoi6	
 硋	ngoi6	
@@ -15514,7 +15514,7 @@ import_tables:
 𨕬	ngok6	
 𨯫	ngok6	
 𩓥	ngok6	
-䯃	ngon1	
+𩣑	ngon1	
 氨	ngon1	
 胺	ngon1	
 銨	ngon1	
@@ -15686,7 +15686,7 @@ import_tables:
 𡩋	ning4	
 𤪥	ning4	
 𧭈	ning4	
-𫛢	ning4	
+鸋	ning4	
 䔭	ning5	
 㣷	ning6	
 㲌	ning6	
@@ -15708,7 +15708,7 @@ import_tables:
 䌰	nip6	
 䎎	nip6	
 䯀	nip6	
-䯅	nip6	
+䯀	nip6	
 䳖	nip6	
 捏	nip6	
 捻	nip6	
@@ -15738,7 +15738,7 @@ import_tables:
 㒟	niu5	
 㜵	niu5	
 㠡	niu5	
-㭤	niu5	
+樢	niu5	
 䃵	niu5	
 䉆	niu5	
 䙚	niu5	
@@ -15831,7 +15831,7 @@ import_tables:
 㛴	nou5	
 㺁	nou5	
 䜀	nou5	
-䜧	nou5	
+䜀	nou5	
 努	nou5	
 堖	nou5	
 弩	nou5	
@@ -15850,7 +15850,7 @@ import_tables:
 朒	nuk6	
 衂	nuk6	
 衄	nuk6	
-㶶	nung1	
+燶	nung1	
 燶	nung1	
 𪒬	nung1	
 㺜	nung4	
@@ -16015,7 +16015,7 @@ import_tables:
 噢	ou3	
 墺	ou3	
 奧	ou3	
-岙	ou3	
+嶴	ou3	
 嶴	ou3	
 懊	ou3	
 澳	ou3	
@@ -16038,7 +16038,7 @@ import_tables:
 帊	paa3	
 怕	paa3	
 袙	paa3	
-䎬	paa4	
+䎱	paa4	
 䎱	paa4	
 扒	paa4	
 掱	paa4	
@@ -16335,7 +16335,7 @@ import_tables:
 䑀	pik1	
 䡶	pik1	
 䤨	pik1	
-䴙	pik1	
+鸊	pik1	
 僻	pik1	
 劈	pik1	
 堛	pik1	
@@ -16444,7 +16444,7 @@ import_tables:
 𦱾	ping4	
 𨥾	ping4	
 𨸶	ping4	
-𫚒	ping4	
+鮄	ping4	
 㧙	pit3	
 䋢	pit3	
 䥕	pit3	
@@ -16589,7 +16589,7 @@ import_tables:
 痡	pou1	
 鋪	pou1	
 鯆	pou1	
-𫚙	pou1	
+鯆	pou1	
 圃	pou2	
 普	pou2	
 氆	pou2	
@@ -16732,7 +16732,7 @@ import_tables:
 㗶	put3	
 㛘	put3	
 㧊	put3	
-䥽	put3	
+鏺	put3	
 䪬	put3	
 潑	put3	
 醱	put3	
@@ -16782,7 +16782,7 @@ import_tables:
 蓰	saai2	
 諰	saai2	
 蹝	saai2	
-𫍰	saai2	
+諰	saai2	
 㬠	saai3	
 䵘	saai3	
 哂	saai3	
@@ -16800,11 +16800,11 @@ import_tables:
 梀	saak3	
 索	saak3	
 𢱢	saak3	
-㡎	saam1	
+幓	saam1	
 㰑	saam1	
 㺑	saam1	
 䀐	saam1	
-䅟	saam1	
+穇	saam1	
 三	saam1	
 仨	saam1	
 叁	saam1	
@@ -17026,12 +17026,12 @@ import_tables:
 襂	sam1	
 襳	sam1	
 郴	sam1	
-鯵	sam1	
+鰺	sam1	
 𡑕	sam1	
 𣿯	sam1	
 𤀻	sam1	
 𨨥	sam1	
-𬘭	sam1	
+綝	sam1	
 㕴	sam2	
 㧲	sam2	
 㰂	sam2	
@@ -17231,7 +17231,7 @@ import_tables:
 𦺋	sau1	
 㝊	sau2	
 㟬	sau2	
-䉤	sau2	
+籔	sau2	
 䏂	sau2	
 䭭	sau2	
 叟	sau2	
@@ -17255,7 +17255,7 @@ import_tables:
 𢯱	sau2	
 𥈟	sau2	
 𩠐	sau2	
-𫍲	sau2	
+謏	sau2	
 㛢	sau3	
 嗽	sau3	
 宿	sau3	
@@ -17293,7 +17293,7 @@ import_tables:
 㕐	se2	
 㝍	se2	
 䥱	se2	
-䥾	se2	
+䥱	se2	
 䬷	se2	
 寫	se2	
 捨	se2	
@@ -17384,7 +17384,7 @@ import_tables:
 須	seoi1	
 𤟠	seoi1	
 𦷪	seoi1	
-㑔	seoi2	
+㑯	seoi2	
 㑯	seoi2	
 㝽	seoi2	
 䅡	seoi2	
@@ -17413,7 +17413,7 @@ import_tables:
 税	seoi3	0%
 繀	seoi3	
 蛻	seoi3	
-蜕	seoi3	0%
+蛻	seoi3	0%
 裞	seoi3	
 說	seoi3	
 説	seoi3	0%
@@ -17446,7 +17446,7 @@ import_tables:
 䆊	seoi6	
 䆳	seoi6	
 䉌	seoi6	
-䍁	seoi6	
+繸	seoi6	
 䔹	seoi6	
 䠔	seoi6	
 䡵	seoi6	
@@ -17645,7 +17645,7 @@ import_tables:
 䫢	si1	
 䲉	si1	
 䲩	si1	
-䴓	si1	
+鳾	si1	
 俬	si1	
 偲	si1	
 僿	si1	
@@ -17715,7 +17715,7 @@ import_tables:
 𩅰	si1	
 𪀔	si1	
 𪆓	si1	
-𫚕	si1	
+鰤	si1	
 㕜	si2	
 㹬	si2	
 䂠	si2	
@@ -17727,7 +17727,7 @@ import_tables:
 死	si2	
 諰	si2	
 𧳅	si2	
-𫍰	si2	
+諰	si2	
 㣈	si3	
 㳏	si3	
 䛈	si3	
@@ -17930,8 +17930,8 @@ import_tables:
 䡪	sin3	
 䤼	sin3	
 䥇	sin3	
-䦂	sin3	
-䦅	sin3	
+䥇	sin3	
+鐥	sin3	
 䨘	sin3	
 䨷	sin3	
 䵇	sin3	
@@ -18028,7 +18028,7 @@ import_tables:
 胜	sing3	
 㞼	sing4	
 㼩	sing4	
-䋲	sing4	
+繩	sing4	
 䡕	sing4	
 䫆	sing4	
 䮪	sing4	
@@ -18123,7 +18123,7 @@ import_tables:
 躠	sit3	
 靾	sit3	
 𥜽	sit3	
-䞌	sit6	
+𧵳	sit6	
 舌	sit6	
 𧵳	sit6	
 㩋	siu1	
@@ -18132,7 +18132,7 @@ import_tables:
 㴅	siu1	
 㶮	siu1	
 䌃	siu1	
-䔥	siu1	
+蕭	siu1	
 䨭	siu1	
 䴛	siu1	
 宵	siu1	
@@ -18165,7 +18165,7 @@ import_tables:
 筱	siu2	
 篠	siu2	
 謏	siu2	
-𫍲	siu2	
+謏	siu2	
 㔅	siu3	
 㗛	siu3	
 䊥	siu3	
@@ -18244,7 +18244,7 @@ import_tables:
 傻	so4	
 𠿬	soe4	
 𡄽	soe4	
-䀥	soek3	
+䁻	soek3	
 䁻	soek3	
 削	soek3	
 勺	soek3	
@@ -18252,7 +18252,7 @@ import_tables:
 爍	soek3	
 鑠	soek3	
 𠸑	soek3	
-㐮	soeng1	
+襄	soeng1	
 㕠	soeng1	
 䉶	soeng1	
 䌮	soeng1	
@@ -18396,7 +18396,7 @@ import_tables:
 㛐	sou2	
 㛮	sou2	
 䈹	sou2	
-䉤	sou2	
+籔	sou2	
 䕅	sou2	
 嫂	sou2	
 掃	sou2	
@@ -18434,7 +18434,7 @@ import_tables:
 㜚	suk1	
 㝛	suk1	
 㬘	suk1	
-㴋	suk1	
+潚	suk1	
 㴼	suk1	
 㶖	suk1	
 䃤	suk1	
@@ -18502,7 +18502,7 @@ import_tables:
 蜙	sung1	
 鬆	sung1	
 𥯆	sung1	
-㧐	sung2	
+㩳	sung2	
 㨦	sung2	
 㩳	sung2	
 傱	sung2	
@@ -18827,7 +18827,7 @@ import_tables:
 撻	taat1	5%
 㒓	taat3	
 㣵	taat3	
-㳠	taat3	
+澾	taat3	
 㿹	taat3	
 撻	taat3	
 澾	taat3	
@@ -18841,7 +18841,7 @@ import_tables:
 韃	taat3	
 鰨	taat3	
 㔸	tai1	
-䴘	tai1	
+鷉	tai1	
 梯	tai1	
 銻	tai1	
 鷈	tai1	
@@ -18913,8 +18913,8 @@ import_tables:
 鷤	tai4	
 𧡰	tai4	
 𪂿	tai4	
-𫘨	tai4	
-𫛸	tai4	
+騠	tai4	
+鶗	tai4	
 㼵	tai5	
 䑯	tai5	
 娣	tai5	
@@ -18944,7 +18944,7 @@ import_tables:
 䕨	tang4	
 䠮	tang4	
 䲍	tang4	
-䲢	tang4	
+鰧	tang4	
 滕	tang4	
 疼	tang4	
 籐	tang4	
@@ -19006,7 +19006,7 @@ import_tables:
 毻	teoi3	
 煺	teoi3	
 蛻	teoi3	
-蜕	teoi3	0%
+蛻	teoi3	0%
 退	teoi3	
 駾	teoi3	
 㢈	teoi4	
@@ -19014,15 +19014,15 @@ import_tables:
 㿉	teoi4	
 㿗	teoi4	
 䀃	teoi4	
-䅪	teoi4	
+𥢢	teoi4	
 僓	teoi4	
 穨	teoi4	
 隤	teoi4	
 頹	teoi4	
 魋	teoi4	
 𠒺	teoi4	
-𬓼	teoi4	
-𬯎	teoi4	
+穨	teoi4	
+隤	teoi4	
 䝎	teon1	
 䵎	teon1	
 啍	teon1	
@@ -19095,7 +19095,7 @@ import_tables:
 㙉	tin2	
 㥏	tin2	
 䐌	tin2	
-䩄	tin2	
+靦	tin2	
 淟	tin2	
 腆	tin2	
 覥	tin2	
@@ -19638,9 +19638,9 @@ import_tables:
 罋	ung3	
 蕹	ung3	
 齆	ung3	
-㖞	waa1	
+喎	waa1	
 䨟	waa1	
-䯄	waa1	
+騧	waa1	
 䵷	waa1	
 凹	waa1	
 咼	waa1	
@@ -19668,7 +19668,7 @@ import_tables:
 搲	waa2	
 畫	waa2	
 𢱑	waa2	
-㟆	waa4	
+㠏	waa4	
 㠏	waa4	
 㦊	waa4	
 㭉	waa4	
@@ -19726,8 +19726,8 @@ import_tables:
 蘾	waai6	
 㕷	waak1	
 㗲	waak1	
-𠵾	waak1	
-㓰	waak6	
+㗲	waak1	
+劃	waak6	
 㖪	waak6	
 㦎	waak6	
 㦯	waak6	
@@ -19779,7 +19779,7 @@ import_tables:
 闤	waan4	
 頑	waan4	
 鬟	waan4	
-鹮	waan4	
+䴉	waan4	
 𡦃	waan4	
 挽	waan5	
 輓	waan5	
@@ -19849,7 +19849,7 @@ import_tables:
 㷐	wai2	
 䃣	wai2	
 䍴	wai2	
-䓕	wai2	
+薳	wai2	
 䛼	wai2	
 䦱	wai2	
 卉	wai2	
@@ -19943,7 +19943,7 @@ import_tables:
 㙔	wai5	
 㨊	wai5	
 㬙	wai5	
-㭏	wai5	
+椲	wai5	
 䈧	wai5	
 䍷	wai5	
 䪘	wai5	
@@ -20020,28 +20020,28 @@ import_tables:
 㬈	wan1	
 㼔	wan1	
 奫	wan1	
-榅	wan1	0%
+榲	wan1	0%
 榲	wan1	
 殟	wan1	
-氲	wan1	0%
+氳	wan1	0%
 氳	wan1	
 温	wan1	0%
 溫	wan1	
-煴	wan1	0%
+熅	wan1	0%
 熅	wan1	
 瘟	wan1	
 緼	wan1	0%
 縕	wan1	
 蒀	wan1	0%
 蒕	wan1	
-蕰	wan1	
+薀	wan1	
 薀	wan1	
 蝹	wan1	
 豱	wan1	
 贇	wan1	
 輼	wan1	0%
 轀	wan1	
-辒	wan1	
+轀	wan1	
 頵	wan1	
 馧	wan1	
 鰛	wan1	0%
@@ -20202,7 +20202,7 @@ import_tables:
 嗢	wat1	
 尉	wat1	
 屈	wat1	
-榅	wat1	0%
+榲	wat1	0%
 榲	wat1	
 灪	wat1	
 煀	wat1	
@@ -20283,8 +20283,8 @@ import_tables:
 𦻑	wing6	
 𩓙	wing6	
 𪷿	wing6	
-㳡	wo1	
-㶽	wo1	
+濄	wo1	
+煱	wo1	
 㹻	wo1	
 䆧	wo1	
 䆼	wo1	
@@ -20349,7 +20349,7 @@ import_tables:
 汪	wong1	
 𡯁	wong1	
 𡯂	wong1	
-㲿	wong2	
+瀇	wong2	
 㳹	wong2	
 㴏	wong2	
 枉	wong2	
@@ -20398,7 +20398,7 @@ import_tables:
 鷬	wong4	
 黃	wong4	
 𤾗	wong4	
-𫗮	wong4	
+餭	wong4	
 往	wong5	
 䌙	wong6	
 旺	wong6	
@@ -20535,7 +20535,7 @@ import_tables:
 㑹	wui6	
 㞧	wui6	
 㱱	wui6	
-㻅	wui6	
+璯	wui6	
 䢈	wui6	
 䫭	wui6	
 匯	wui6	
@@ -20861,7 +20861,7 @@ import_tables:
 𠲜	zaang1	
 𧶄	zaang1	
 䦛	zaang3	
-䦶	zaang3	
+䦛	zaang3	
 諍	zaang3	
 䂻	zaang6	
 掙	zaang6	
@@ -20945,11 +20945,11 @@ import_tables:
 棹	zaau6	
 櫂	zaau6	
 驟	zaau6	
-㨈	zai1	
+擠	zai1	
 䂑	zai1	
 䜞	zai1	
 䝴	zai1	
-䠁	zai1	
+躋	zai1	
 䪠	zai1	
 䪡	zai1	
 䪢	zai1	
@@ -20970,7 +20970,7 @@ import_tables:
 囝	zai2	
 濟	zai2	
 㝂	zai3	
-㴉	zai3	
+濟	zai3	
 䇽	zai3	
 䎺	zai3	
 䨖	zai3	
@@ -21245,24 +21245,24 @@ import_tables:
 㫶	zau2	
 㷌	zau2	
 䖞	zau2	
-䲤	zau2	
+鿐	zau2	
 帚	zau2	
 睭	zau2	
 肘	zau2	
 走	zau2	
 酒	zau2	
 鯞	zau2	
-㑇	zau3	
+㑳	zau3	
 㑳	zau3	
 㔿	zau3	
-㤘	zau3	
+㥮	zau3	
 㥮	zau3	
 㩆	zau3	
 㼙	zau3	
 㾭	zau3	
 䅢	zau3	
 䊘	zau3	
-䋓	zau3	
+縐	zau3	
 䎻	zau3	
 僽	zau3	
 咒	zau3	
@@ -21460,7 +21460,7 @@ import_tables:
 辠	zeoi6	
 鱮	zeoi6	
 𨣦	zeoi6	
-𫚈	zeoi6	
+鱮	zeoi6	
 㡒	zeon1	
 㰉	zeon1	
 䘒	zeon1	
@@ -21485,7 +21485,7 @@ import_tables:
 迍	zeon1	
 遵	zeon1	
 㯸	zeon2	
-䝲	zeon2	
+贐	zeon2	
 儘	zeon2	
 准	zeon2	
 埻	zeon2	
@@ -21584,7 +21584,7 @@ import_tables:
 㽻	zi1	
 䅔	zi1	
 䊷	zi1	
-䌶	zi1	
+䊷	zi1	
 䎩	zi1	
 䓡	zi1	
 䓩	zi1	
@@ -21662,7 +21662,7 @@ import_tables:
 𤦧	zi1	
 𦔒	zi1	
 𪗋	zi1	
-𫛛	zi1	
+鳷	zi1	
 㕄	zi2	
 㜽	zi2	
 㞨	zi2	
@@ -21958,13 +21958,13 @@ import_tables:
 魙	zim6	
 𨮜	zim6	
 㡐	zin1	
-㦮	zin1	
+戔	zin1	
 㫋	zin1	
 㮍	zin1	
 㮵	zin1	
 㰄	zin1	
 㷙	zin1	
-䇳	zin1	
+箋	zin1	
 䊕	zin1	
 䍹	zin1	
 䙁	zin1	
@@ -22036,7 +22036,7 @@ import_tables:
 𧬆	zin2	
 𨃨	zin2	
 𨫀	zin2	
-䬻	zin3	
+餞	zin3	
 墊	zin3	
 戰	zin3	
 栫	zin3	
@@ -22061,7 +22061,7 @@ import_tables:
 䋊	zing1	
 䒱	zing1	
 䕄	zing1	
-䴖	zing1	
+鶄	zing1	
 偵	zing1	
 征	zing1	
 徵	zing1	
@@ -22117,7 +22117,7 @@ import_tables:
 𦭒	zing3	
 㣏	zing6	
 䝼	zing6	
-䞍	zing6	
+䝼	zing6	
 凈	zing6	
 凊	zing6	
 剩	zing6	
@@ -22301,7 +22301,7 @@ import_tables:
 㩱	zoek3	
 㹱	zoek3	
 䅵	zoek3	
-䦃	zoek3	
+鐯	zoek3	
 䧿	zoek3	
 䮓	zoek3	
 䲵	zoek3	
@@ -22336,7 +22336,7 @@ import_tables:
 𨧧	zoek3	
 𨫠	zoek3	
 𨰜	zoek3	
-䦃	zoek6	
+鐯	zoek6	
 着	zoek6	
 著	zoek6	
 𤏲	zoek6	
@@ -22544,7 +22544,7 @@ import_tables:
 𡠻	zou6	
 𨘥	zou6	
 𪣝	zou6	
-㔉	zuk1	
+劚	zuk1	
 㗤	zuk1	
 䈞	zuk1	
 䌵	zuk1	
@@ -22682,7 +22682,7 @@ import_tables:
 䰌	zung2	
 傯	zung2	
 尰	zung2	
-捴	zung2	
+摠	zung2	
 摠	zung2	
 熜	zung2	
 种	zung2	
@@ -22794,7 +22794,7 @@ import_tables:
 櫡	zyu6	
 箸	zyu6	
 㼷	zyun1	
-䏝	zyun1	
+膞	zyun1	
 䘒	zyun1	
 䧠	zyun1	
 塼	zyun1	
@@ -25290,7 +25290,7 @@ import_tables:
 爸爸	baa4 baa4
 爸打	baa1 daa2
 爸媽	baa1 maa1
-鲅魚圈區	bat6 jyu2 hyun1 keoi1
+鮁魚圈區	bat6 jyu2 hyun1 keoi1
 罷斥	baa6 cik1
 罷黜	baa6 zyut6
 罷黜	baa6 ceot1
@@ -28755,7 +28755,7 @@ import_tables:
 本科	bun2 fo1
 本科生	bun2 fo1 sang1
 本拉登	bun2 laai1 dang1
-本来	bun2 loi4
+本來	bun2 loi4
 本來	bun2 loi4
 本來面目	bun2 loi4 min6 muk6
 本壘	bun2 leoi5
@@ -30481,7 +30481,7 @@ import_tables:
 癟陷	bit6 haam6
 彆扭	bit3 nau2
 彆嘴	bit3 zeoi2
-宾舟	ban1 zau1
+賓舟	ban1 zau1
 彬彬	ban1 ban1
 彬彬君子	ban1 ban1 gwan1 zi2
 彬彬有禮	ban1 ban1 jau5 lai5
@@ -31261,7 +31261,7 @@ import_tables:
 剝啄	mok1 doek3
 菠菜	bo1 coi3
 菠菜豆腐	bo1 coi3 dau6 fu6
-菠萝包	bo1 lo4 baau1
+菠蘿包	bo1 lo4 baau1
 菠蘿	bo1 lo4
 菠蘿包	bo1 lo4 baau1
 菠蘿彈	bo1 lo4 daan6
@@ -33519,7 +33519,7 @@ import_tables:
 彩雀	coi2 zoek3
 彩色	coi2 sik1
 彩色電視	coi2 sik1 din6 si6
-彩数	coi2 sou3
+彩數	coi2 sou3
 彩數	coi2 sou3
 彩塑	coi2 sou3
 彩陶	coi2 tou4
@@ -33532,7 +33532,7 @@ import_tables:
 彩鷸	coi2 wat6
 彩雲	coi2 wan4
 彩妝	coi2 zong1
-䌽帶	coi2 daai2
+綵帶	coi2 daai2
 睬…都有味	coi2 dou1 jau5 mei6
 睬你都傻	coi2 nei5 dou1 so4
 睬你都生臭狐	coi2 nei5 dou1 saang1 cau3 wu4
@@ -33548,7 +33548,7 @@ import_tables:
 踩車	caai2 ce1
 踩嚫條尾	caai2 can3 tiu4 mei5
 踩錯腳	caai2 co3 goek3
-踩单车	caai2 daan1 ce1
+踩單車	caai2 daan1 ce1
 踩單車	caai2 daan1 ce1
 踩單車	caai1 daan1 ce1
 踩單車	jaai2 daan1 ce1
@@ -33663,7 +33663,7 @@ import_tables:
 蔡元培	coi3 jyun4 pui4
 蔡志忠	coi3 zi3 zung1
 蔡卓妍	coi3 coek3 jin4
-参加	caam1 gaa1
+參加	caam1 gaa1
 參拜	caam1 baai3
 參半	caam1 bun3
 參茶	sam1 caa4
@@ -36160,7 +36160,7 @@ import_tables:
 潮州粉粿	ciu4 zau1 fan2 gwo2
 潮州柑	ciu4 zau1 gam1
 潮州花燈	ciu4 zau1 faa1 dang1
-潮州话	ciu4 zau1 waa2
+潮州話	ciu4 zau1 waa2
 潮州話	ciu4 zau1 waa2
 潮州市	ciu4 zau1 si5
 潮州水晶包	ciu4 zau1 seoi2 zing1 baau1
@@ -37564,7 +37564,7 @@ import_tables:
 癡人說夢	ci1 jan4 syut3 mung6
 癡傻	ci1 so4
 癡騃	ci1 ngoi4
-癡线	ci1 sin3
+癡線	ci1 sin3
 癡綫	ci1 sin3
 癡想	ci1 soeng2
 癡笑	ci1 siu3
@@ -42760,7 +42760,7 @@ import_tables:
 大力水手	daai6 lik6 seoi2 sau2
 大力透氣	daai6 lik6 tau2 hei3
 大利拉	daai6 lei6 laai1
-大沥	daai6 lik6
+大瀝	daai6 lik6
 大荔	daai6 lai6
 大荔縣	daai6 lai6 jyun6
 大粒	daai6 lap1
@@ -43934,7 +43934,7 @@ import_tables:
 戴維營	daai3 wai4 jing4
 戴孝	daai3 haau3
 戴孝	daai6 haau3
-戴眼镜	daai3 ngaan5 geng3
+戴眼鏡	daai3 ngaan5 geng3
 戴眼鏡	daai3 ngaan5 geng2
 戴有色眼鏡	daai3 jau5 sik1 ngaan5 geng2
 戴月披星	daai3 jyut6 pei1 sing1
@@ -58590,7 +58590,7 @@ import_tables:
 戈氏金絲燕	gwo1 si6 gam1 si1 jin3
 戈氏岩鵐	gwo1 si6 ngaam4 mou4
 戈斯拉爾	gwo1 si1 laai1 ji5
-圪垯	ngat6 daat3
+圪墶	ngat6 daat3
 疙瘩	gat6 daap3
 疙疸	gat6 taan2
 咯嚓	lok3 caat3
@@ -60745,7 +60745,7 @@ import_tables:
 姑子	gu1 zi2
 唂咕	guk1 gu2
 唂咕	guk1 gu1
-唂精上脑	guk1 zing1 soeng5 nou5
+唂精上腦	guk1 zing1 soeng5 nou5
 唂精上腦	guk1 zing1 soeng5 nou5
 唂氣	guk1 hei3
 辜負	gu1 fu6
@@ -63420,7 +63420,7 @@ import_tables:
 國足	gwok3 zuk1
 國族	gwok3 zuk6
 國祚	gwok3 zou6
-腘窩	gwok3 wo1
+膕窩	gwok3 wo1
 摑耳光	gwaak3 ji5 gwong1
 摑一巴掌	gwaak3 jat1 baa1 zoeng2
 果報	gwo2 bou3
@@ -65319,7 +65319,7 @@ import_tables:
 好不好	hou2 bat1 hou2
 好不容易	hou2 bat1 jung4 ji6
 好彩	hou2 coi2
-好彩数	hou2 coi2 sou3
+好彩數	hou2 coi2 sou3
 好彩數	hou2 coi2 sou3
 好殘	hou2 caan4
 好嘈	hou2 cou4
@@ -65498,7 +65498,7 @@ import_tables:
 好命水	hou2 meng6 seoi2
 好耐	hou2 noi6
 好耐好耐之前	hou2 noi6 hou2 noi6 zi1 cin4
-好耐冇见	hou2 noi6 mou5 gin3
+好耐冇見	hou2 noi6 mou5 gin3
 好耐冇見	hou2 noi6 mou5 gin3
 好男不跟女鬥	hou2 naam4 bat1 gan1 neoi5 dau3
 好嫩	hou2 nyun6
@@ -71941,7 +71941,7 @@ import_tables:
 或是	waak6 si6
 或體	waak6 tai2
 或者	waak6 ze2
-𠵾𠵾	waak1 waak1
+㗲㗲	waak1 waak1
 貨辦	fo3 baan2
 貨比三家	fo3 bei2 saam1 gaa1
 貨比三家不吃虧	fo3 bei2 saam1 gaa1 bat1 hek3 kwai1
@@ -79976,7 +79976,7 @@ import_tables:
 精細	zing1 sai3
 精校本	zing1 gaau3 bun2
 精心	zing1 sam1
-精选	zing1 syun2
+精選	zing1 syun2
 精選	zing1 syun2
 精選輯	zing1 syun2 cap1
 精研	zing1 jin4
@@ -80315,7 +80315,7 @@ import_tables:
 凈身出戶	zeng6 san1 ceot1 wu6
 凈係	zing6 hai6
 凈心修身	zing6 sam1 sau1 san1
-竞选	ging6 syun2
+竞選	ging6 syun2
 弳度	ging3 dou6
 脛骨	ging3 gwat1
 脛骨	hing5 gwat1
@@ -81222,7 +81222,7 @@ import_tables:
 拘役	keoi1 jik6
 拘迂	keoi1 jyu1
 拘執	keoi1 zap1
-苴斗货	zaa2 dau2 fo3
+苴斗貨	zaa2 dau2 fo3
 苴麻	ceoi1 maa4
 苴皮	zaa2 pei4
 苴嘢	zaa2 je5
@@ -83274,7 +83274,7 @@ import_tables:
 看管	hon1 gun2
 看慣	hon3 gwaan3
 看好	hon3 hou2
-看护	hon1 wu6
+看護	hon1 wu6
 看護	hon1 wu6
 看花眼	hon3 faa1 ngaan5
 看家	hon1 gaa1
@@ -85203,7 +85203,7 @@ import_tables:
 褲髀	fu3 bei2
 褲衩	fu3 caa3
 褲穿窿	fu3 cyun1 lung4
-褲带	fu3 daai2
+褲帶	fu3 daai2
 褲帶	fu3 daai2
 褲袋	fu3 doi2
 褲襠	fu3 dong1
@@ -85889,7 +85889,7 @@ import_tables:
 闊口拿扒	fut3 hau2 naa4 paa4
 闊老	fut3 lou5
 闊佬	fut3 lou2
-闊佬懒理	fut3 lou2 laan5 lei5
+闊佬懶理	fut3 lou2 laan5 lei5
 闊佬懶理	fut3 lou2 laan5 lei5
 闊咧啡	fut3 le4 fe4
 闊落	fut3 lok6
@@ -88988,10 +88988,10 @@ import_tables:
 利什曼病	lei6 sam6 maan6 beng6
 利市	lai6 si6
 利市	lei6 si6
-利市逗来	lai6 si6 dau6 loi4
-利市逗来	lei6 si6 dau6 loi4
-利市𢭃来	lai6 si6 dau6 loi4
-利市𢭃来	lei6 si6 dau6 loi4
+利市逗來	lai6 si6 dau6 loi4
+利市逗來	lei6 si6 dau6 loi4
+利市𢭃來	lai6 si6 dau6 loi4
+利市𢭃來	lei6 si6 dau6 loi4
 利市封	lai6 si6 fung1
 利市封	lei6 si6 fung1
 利市錢	lai6 si6 cin2
@@ -88999,10 +88999,10 @@ import_tables:
 利市錢	lai6 si6 cin4
 利事	lai6 si6
 利事	lei6 si6
-利事逗来	lai6 si6 dau6 loi4
-利事逗来	lei6 si6 dau6 loi4
-利事𢭃来	lai6 si6 dau6 loi4
-利事𢭃来	lei6 si6 dau6 loi4
+利事逗來	lai6 si6 dau6 loi4
+利事逗來	lei6 si6 dau6 loi4
+利事𢭃來	lai6 si6 dau6 loi4
+利事𢭃來	lei6 si6 dau6 loi4
 利事封	lai6 si6 fung1
 利事封	lei6 si6 fung1
 利事錢	lai6 si6 cin2
@@ -89010,10 +89010,10 @@ import_tables:
 利事錢	lai6 si6 cin4
 利是	lai6 si6
 利是	lei6 si6
-利是逗来	lai6 si6 dau6 loi4
-利是逗来	lei6 si6 dau6 loi4
-利是𢭃来	lai6 si6 dau6 loi4
-利是𢭃来	lei6 si6 dau6 loi4
+利是逗來	lai6 si6 dau6 loi4
+利是逗來	lei6 si6 dau6 loi4
+利是𢭃來	lai6 si6 dau6 loi4
+利是𢭃來	lei6 si6 dau6 loi4
 利是封	lai6 si6 fung1
 利是封	lei6 si6 fung1
 利是錢	lai6 si6 cin2
@@ -89511,7 +89511,7 @@ import_tables:
 漣源	lin4 jyun4
 漣源地區	lin4 jyun4 dei6 keoi1
 漣源市	lin4 jyun4 si5
-噒榄核	leon1 laam5 wat6
+噒欖核	leon1 laam5 wat6
 噒諄	leon1 zeon1
 憐愛	lin4 oi3
 憐憫	lin4 man5
@@ -90944,7 +90944,7 @@ import_tables:
 凜抌	lam5 dam2
 凜遵	lam5 zeon1
 吝盡	leon6 zeon6
-吝啬	leon6 sik1
+吝嗇	leon6 sik1
 吝嗇	leon6 sik1
 吝嗇鬼	leon6 sik1 gwai2
 吝惜	leon6 sik1
@@ -95972,7 +95972,7 @@ import_tables:
 冇文化	mou5 man4 faa3
 冇紋路	mou5 man4 lou6
 冇紋冇路	mou5 man4 mou5 lou6
-冇问题	mou5 man6 tai4
+冇問題	mou5 man6 tai4
 冇問	mou5 man6
 冇問題	mou5 man6 tai4
 冇搵	mou5 wan2
@@ -103410,7 +103410,7 @@ import_tables:
 爬犁	paa4 lai4
 爬牆	paa4 coeng4
 爬山	paa4 saan1
-爬山单车	paa4 saan1 daan1 ce1
+爬山單車	paa4 saan1 daan1 ce1
 爬山單車	paa4 saan1 daan1 ce1
 爬山虎	paa4 saan1 fu2
 爬山涉水	paa4 saan1 sip3 seoi2
@@ -107109,7 +107109,7 @@ import_tables:
 淇濱區	kei4 ban1 keoi1
 淇淋	kei4 lam4
 淇縣	kei4 jyun6
-骑呢拐	ke4 le4 gwaai2
+騎呢拐	ke4 le4 gwaai2
 棋差一着	kei4 caa1 jat1 zoek6
 棋逢敵手	kei4 fung4 dik6 sau2
 棋逢對手	kei4 fung4 deoi3 sau2
@@ -109992,8 +109992,8 @@ import_tables:
 青壯年	cing1 zong3 nin4
 青紫	ceng1 zi2
 青字頭	cing1 zi6 tau4
-倾偈	king1 gai2
-倾铃䆲䆡	king1 ling1 kwaang1 laang1
+傾偈	king1 gai2
+傾鈴䆲䆡	king1 ling1 kwaang1 laang1
 卿卿我我	hing1 hing1 ngo5 ngo5
 氫彈	hing1 daan2
 氫氟酸	hing1 fat1 syun1
@@ -117916,7 +117916,7 @@ import_tables:
 設有	cit3 jau5
 設在	cit3 zoi6
 設置	cit3 zi3
-摄青鬼	sip3 ceng1 gwai2
+攝青鬼	sip3 ceng1 gwai2
 摵起條筋	cik1 hei2 tiu4 gan1
 摵甩	mit1 lat1
 攝嚫	sip3 can3
@@ -119972,8 +119972,8 @@ import_tables:
 施政報告	si1 zing3 bou3 gou3
 施粥捨飯	si1 zuk1 se2 faan6
 施主	si1 zyu2
-浉河	si1 ho4
-浉河區	si1 ho4 keoi1
+溮河	si1 ho4
+溮河區	si1 ho4 keoi1
 屍斑	si1 baan1
 屍布	si1 bou3
 屍臭	si1 cau3
@@ -120920,7 +120920,7 @@ import_tables:
 食字邊	sik6 zi6 bin1
 食咗	sik6 zo2
 食咗草龍	sik6 zo2 cou2 lung4
-食咗饭未啊	sik6 zo2 faan6 mei6 aa3
+食咗飯未啊	sik6 zo2 faan6 mei6 aa3
 食咗飯未	sik6 zo2 faan6 mei6
 食咗飯未吖	sik6 zo2 faan6 mei6 aa1
 食咗火藥	sik6 zo2 fo2 joek6
@@ -127668,7 +127668,7 @@ import_tables:
 台球	toi2 kau4
 台球桌	toi2 kau4 coek3
 台山	toi4 saan1
-台山话	toi4 saan1 waa2
+台山話	toi4 saan1 waa2
 台山話	toi4 saan1 waa2
 台山市	toi4 saan1 si5
 台商	toi4 soeng1
@@ -128295,7 +128295,7 @@ import_tables:
 坦白	taan2 baak6
 坦博拉	taan2 bok3 laai1
 坦陳	taan2 can4
-坦诚	taan2 sing4
+坦誠	taan2 sing4
 坦承	taan2 sing4
 坦誠	taan2 sing4
 坦誠相見	taan2 sing4 soeng1 gin3
@@ -135118,7 +135118,7 @@ import_tables:
 逶迤	wai1 ji4
 偎傍	wui1 bong6
 葳蕤	wai1 jeoi4
-喴哗鬼叫	wi1 waa1 gwai2 giu3
+喴嘩鬼叫	wi1 waa1 gwai2 giu3
 微安	mei4 on1
 微安培	mei4 on1 pui4
 微薄	mei4 bok6
@@ -136799,7 +136799,7 @@ import_tables:
 蝸牛	wo1 ngau4
 蝸旋	wo1 syun4
 蝸蜒	wo1 jin4
-我爱你	ngo5 oi3 nei5
+我愛你	ngo5 oi3 nei5
 我愛你	ngo5 oi3 nei5
 我輩	ngo5 bui3
 我比	ngo5 bei2
@@ -137423,7 +137423,7 @@ import_tables:
 唔該嗮	m4 goi1 saai3
 唔該晒	m4 goi1 saai3
 唔敢	m4 gam2
-唔敢当	m4 gam2 dong1
+唔敢當	m4 gam2 dong1
 唔敢當	m4 gam2 dong1
 唔趕	m4 gon2
 唔高興	m4 gou1 hing3
@@ -142161,7 +142161,7 @@ import_tables:
 香骨	hoeng1 gwat1
 香瓜	hoeng1 gwaa1
 香瓜汁	hoeng1 gwaa1 zap1
-香闺	hoeng1 gwai1
+香閨	hoeng1 gwai1
 香閨	hoeng1 gwai1
 香桂	hoeng1 gwai3
 香汗淋漓	hoeng1 hon6 lam4 lei4
@@ -144275,7 +144275,7 @@ import_tables:
 心眼小	sam1 ngaan5 siu2
 心癢	sam1 joeng5
 心野	sam1 je5
-心仪	sam1 ji4
+心儀	sam1 ji4
 心疑	sam1 ji4
 心儀	sam1 ji4
 心悒	sam1 ngap1
@@ -145719,7 +145719,7 @@ import_tables:
 休閒鞋	jau1 haan4 haai4
 休想	jau1 soeng2
 休學	jau1 hok6
-休养所	jau1 joeng5 so2
+休養所	jau1 joeng5 so2
 休養	jau1 joeng5
 休養生息	jau1 joeng5 sang1 sik1
 休養所	jau1 joeng5 so2
@@ -148014,8 +148014,8 @@ import_tables:
 腌悶	jim1 mun6
 腌肉	jim1 juk6
 腌魚	jip3 jyu2
-腌臜	ap1 zap1
-腌臜	jim1 zim1
+腌臢	ap1 zap1
+腌臢	jim1 zim1
 腌臢	jim1 zim1
 腌製	jip3 zai3
 湮沒	jin1 mut6
@@ -148141,7 +148141,7 @@ import_tables:
 醃肉	jim1 juk6
 醃肉	jip3 juk6
 醃眼	jip3 ngaan5
-醃臜	ap1 zap1
+醃臢	ap1 zap1
 醃汁	jip3 zap1
 醃製	jip3 zai3
 醃豬肉	jip3 zyu1 juk6
@@ -162381,7 +162381,7 @@ import_tables:
 整車	zing2 ce1
 整嚫	zing2 can1
 整成…嘅習慣	zing2 sing4 ge3 zaap6 gwaan3
-整飭整顿	zing2 cik1 zing2 deon6
+整飭整頓	zing2 cik1 zing2 deon6
 整出來	zing2 ceot1 lai4
 整出嚟	zing2 ceot1 lei4
 整除	zing2 ceoi4
@@ -165177,7 +165177,7 @@ import_tables:
 盅頭飯	zung1 tau2 faan6
 盅頭飯	zung1 tau4 faan6
 盅仔飯	zung1 zai2 faan6
-钟意	zung1 ji3
+鈡意	zung1 ji3
 衷腸	cung1 coeng4
 衷誠	cung1 sing4
 衷情	cung1 cing4
@@ -165233,7 +165233,7 @@ import_tables:
 終戰日	zung1 zin3 jat6
 終之	zung1 zi1
 終止	zung1 zi2
-锺意	zung1 ji3
+鍾意	zung1 ji3
 鍾愛	zung1 oi3
 鍾村	zung1 cyun1
 鍾點房	zung1 dim2 fong4
@@ -169907,7 +169907,7 @@ import_tables:
 遵化縣	zeon1 faa3 jyun6
 遵令	zeon1 ling6
 遵命	zeon1 ming6
-遵时養晦	zeon1 si4 joeng5 fui3
+遵時養晦	zeon1 si4 joeng5 fui3
 遵守	zeon1 sau2
 遵循	zeon1 ceon4
 遵醫囑	zeon1 ji1 zuk1


### PR DESCRIPTION
<div lang="zh-HK">

在使用中發現，在香港繁體模式下，輸入 king gai 會產生簡體的「倾偈」，這是因為詞庫中有簡體字的詞條。本次更新將這些字改為 OpenCC 標準用字。

按用户若要使用簡體字，在菜單中切換為「大陆简体」即可。

本次更新檢查了以下簡體字（左簡右繁）：

𫝈㑮,㑔㑯,㑇㑳,𠉂㒓,𠇐㒜,𬾖㒣,𬜯㒼,刾㓨,𪟲㔶,𫩩㗙,𫪺㗣,𠵾㗲,𫪀㗻,𫬐㘔,𫪂㘙,㘎㘚,𫮜㙬,𫝦㛝,㚯㜄,㛣㜏,𡞋㜗,𡞱㜢,𫰨㜥,𫰠㜭,𫲗㜺,𫳃㝞,𪩇㟺,𫶅㠁,㟆㠏,𫵷㠣,𫷅㡓,𢋈㢝,𫺁㤲,㤘㥮,𫺆㦊,𢛯㦎,𪫷㦞,𢙪㦠,𢯉㨙,𫽇㩇,㨫㩜,𫾉㩣,𫽊㩭,㧐㩳,𬖠㪹,𫿳㪻,𬀮㬣,𣗙㰙,𬅢㰰,𬉇㵤,𤆢㷍,𤌈㷶,𤎺㸇,𬊾㸐,𬌛㹂,𫞣㹽,𤠋㺏,𬌷㺑,𪺻㺜,𬎆㼆,𭹜㼈,𬎧㼻,𬏟㾵,𬏜㾺,𬏷㿎,𤻊㿗,𤽯㿧,𬑏䀴,𬑒䁱,䀥䁻,𥎝䂎,𬒎䃘,鿎䃮,𫀨䅐,𥟂䅘,𫀬䅳,𬕛䉐,𫁲䉑,𥳺䉥,𬕦䉱,𥺅䊭,𮇋䊯,𬡻䊲,𮉠䊵,䌶䊷,纤䊹,𫄚䊺,𫄜䋃,𮉣䋏,𬘙䋐,𫄞䋔,䌺䋙,䌻䋚,𫄩䋦,䌿䋹,𬘴䋺,䌾䋻,𫄮䋼,𬘲䋾,𦈓䋿,𬘱䌁,𦈖䌈,𦈘䌋,𬘮䌐,𦈜䌖,𦈟䌝,𬘪䌞,𦈞䌟,𦈠䌥,𦀳䌧,𦈙䌰,𫅅䍤,䍠䍦,𦍠䍽,𫅭䎙,䎬䎱,𬛹䑗,𫟕䕤,𬝴䕼,𫋲䙔,䙌䙡,𬢉䙻,舰䚀,𬢑䚆,𫌯䚩,𬣛䚳,𫍠䛄,𬣯䛘,𫍫䛳,䜧䜀,𬤉䜋,𬣿䜎,𬤡䜒,𬥄䝕,𫎧䝭,𧹕䝻,䞍䝼,𬥺䞁,𧹑䞈,𫎪䞋,𫎭䞓,𫎺䟃,𫎳䟆,𫎱䟐,𬧃䠮,𫟤䡐,𬨆䡗,𬨉䡘,𬨌䡟,𬨑䡦,𫟥䡩,𮝀䡱,𫟦䡵,𬨔䡶,𬨕䡹,𨏨䡿,𮠞䤌,𫟺䤤,𬭆䤪,𬭣䤼,𫠀䥄,䦂䥇,鿏䥑,𫔋䥗,𬭻䥞,𫔆䥯,䥾䥱,𬫂䥶,𮤬䦌,䦶䦛,𬮨䦝,䦷䦟,𫔵䦯,𬮺䧞,𨸟䧢,𫖅䪊,𫖫䪴,𫖱䫀,𬱝䫀,𫖰䫂,𬱣䫈,𬃲䫐,𬱮䫜,𬱰䫠,𩔗䫫,𩖗䫴,𫖺䫶,𫠈䫾,𬲀䬍,𬱿䬎,𫗊䬓,𩗡䬞,𩙧䬞,𫗟䬧,𬳅䭉,𫗱䭑,𬳋䭒,𫗰䭔,𬲲䭢,𬲶䭣,𩧭䭿,𫠊䮄,𬳾䮈,𬴁䮗,𩧰䮝,𩨁䮞,𩧿䮠,𩨇䮫,𫘮䮰,𩨏䮳,𬳸䮸,𬴍䮽,𩦳䮾,𩧪䮾,𬴏䮿,䯅䯀,鲃䰾,𫚐䱀,𫚏䱁,𮬞䱗,𩾈䱙,𮬠䱚,𮬟䱛,𫚠䱧,𬶤䱱,𮬢䱵,䲣䱷,𫠑䱸,𮬡䱻,䲝䱽,鳚䲁,𬶗䲏,𬶴䲕,𩾂䲖,𮬣䲗,鳤䲘,𪉂䲰,𮭡䲸,𮭥䳍,𫛬䳜,𫛰䳢,𫛺䳧,𬸛䳨,𫛼䳫,𬸩䴈,鹮䴉,𫜅䴋,𫜒䴱,𫜔䴽,𬹔䵖,𬓸䵘,𫜙䵴,𫜨䶕,𮯙䶗,𬺍䶢,𬺃䶣,𬺉䶦,𮯈䶨,𪙘䶩,𬺕䶪,𭒗䶯,𫜳䶲,乱亂,亚亞,伫佇,来來,仑侖,𠇹俓,伣俔,侠俠,伡俥,𠈙俴,伥倀,伜倅,俩倆,俫倈,仓倉,𠇂個,们們,伦倫,㑈倲,伟偉,㐽偑,侧側,侦偵,㐷傌,伧傖,伞傘,俻備,𬾨備,𫢺傪,倊傯,传傳,伛傴,债債,伤傷,倾傾,偻僂,𫢪僆,㑒僉,佥僉,𫢙働,侨僑,𫢬僗,伪僞,𫢸僤,侥僥,偾僨,価價,𫣊僾,仪儀,侬儂,亿億,侩儈,俭儉,倹儉,傤儎,傧儐,俦儔,㑪儕,侪儕,𫣉儖,侭儘,偿償,𬽷儣,𫢒儱,储儲,𠋂儳,𠍈儳,俪儷,㑩儸,傩儺,傥儻,俨儼,𠑊儼,两兩,冻凍,凯凱,㞮出,刭剄,则則,刬剗,刚剛,剐剮,剀剴,创創,㓰劃,剧劇,刽劊,刿劌,剑劍,剣劍,𠝏劎,㓥劏,剂劑,剤劑,𠜸劑,剱劒,㔉劚,劲勁,𠡍勁,动動,务務,勋勛,劳勞,势勢,勚勩,劢勱,励勵,勧勸,𭄿勸,匦匭,汇匯,匮匱,区區,卆卒,协協,厍厙,厕厠,厌厭,厉厲,厣厴,参參,丛叢,呙咼,员員,呗唄,𫪁唻,问問,𠯥啐,启啓,哑啞,唡啢,㖞喎,丧喪,乔喬,单單,単單,哟喲,呛嗆,啬嗇,唝嗊,吗嗎,呜嗚,唢嗩,哔嗶,叹嘆,喽嘍,啯嘓,呕嘔,啧嘖,尝嘗,唛嘜,哗嘩,𪡃嘪,唠嘮,啸嘯,嘨嘯,𪡞嘳,哓嘵,呒嘸,𪡀嘺,兽嘼,啴嘽,𠯠噅,㖊噚,咝噝,哒噠,哝噥,哕噦,嗳噯,哙噲,喷噴,𪠽噹,𠵢嚇,𫩫嚈,哜嚌,𠴧嚌,噜嚕,啮嚙,噛嚙,𭇗嚝,呖嚦,𠰷嚧,咙嚨,𠺠嚨,亸嚲,喾嚳,严嚴,厳嚴,嘤嚶,𠼁嚷,𫬄嚷,𪢕嚽,啭囀,𫝚囀,嗫囁,嚣囂,冁囅,呓囈,啰囉,嚢囊,𭌰囓,𫬠囕,囵圇,国國,围圍,圆圓,図圖,图圖,团團,団團,坝垻,垭埡,𡉻埣,𫭢埨,𪣆埬,坚堅,𡉢堅,垩堊,垴堖,𪣒堚,埚堝,尧堯,尭堯,场場,茔塋,垲塏,埘塒,坞塢,埙塤,㘯塲,𫭟塸,堑塹,𫭞塼,𪣻塿,垫墊,𫮅墋,坠墜,𫭪墝,𫮃墠,𫭨墢,堕墮,垯墶,墙墻,垱壋,压壓,𭎜壔,圹壙,垆壚,𭏸壝,壊壞,垄壟,垅壠,𡏡壠,坜壢,𪤚壣,壌壤,𫭲壧,塆壪,壮壯,壶壺,壸壼,寿壽,𮋛壽,夹夾,奁奩,夺奪,𫯶奫,奨奬,𫰂奲,妆妝,𫰛娙,娄婁,𫰐婜,𫝫婡,𫰿婣,妇婦,娅婭,𫰍媁,𫝨媈,娲媧,㛀媰,妈媽,妪嫗,妩嫵,娴嫻,婳嫿,妫嬀,媭嬃,𫰡嬅,𫝬嬇,娆嬈,婵嬋,娇嬌,𫰰嬐,𫰢嬒,嫱嬙,嫒嬡,𪥰嬣,𫝩嬦,嫔嬪,婴嬰,婶嬸,嬢孃,𫝭孆,㛤孋,娈孌,孙孫,学學,孪孿,㝉宁,𪧘寠,寝寢,实實,𡧑實,审審,写寫,宽寬,宠寵,将將,专專,寻尋,对對,导導,尴尷,屃屓,屡屢,层層,屦屨,𪨗屩,岘峴,岛島,峡峽,崃崍,岗崗,𪨧崙,岽崬,𫵵崵,岚嵐,𡶴嵼,𫶇嵽,㟥嵾,嵝嶁,崭嶄,岖嶇,嵚嶔,崂嶗,峤嶠,峣嶢,𡸳嶢,峄嶧,峃嶨,崄嶮,𡸴嶮,岙嶴,嵘嶸,𫝵嶹,屿嶼,𫶕巆,𡺎巉,岿巋,峦巒,巅巓,巌巖,𪨷巗,巯巰,帅帥,师師,帐帳,带帶,帯帶,帧幀,帏幃,㡎幓,帼幗,帻幘,𪩷幝,𭘓幠,𪩸幩,帱幬,库庫,庼廎,𫷮廕,鿮廗,𫷷廞,庑廡,废廢,廃廢,𪪞廧,弪弳,张張,𪪼彃,𫸩彄,弹彈,弾彈,弯彎,彟彠,彨彲,径徑,徕徠,𭛳徯,彻徹,𪫌徿,总悤,忰悴,怅悵,闷悶,恶惡,恼惱,悩惱,恽惲,恻惻,爱愛,惬愜,悫愨,𫺌愩,怆愴,恺愷,𢙏愻,惨慘,惭慚,恸慟,惯慣,怄慪,虑慮,𫹽慯,悭慳,庆慶,㥪慺,惫憊,㤭憍,愦憒,慭憖,惮憚,愤憤,𫺘憦,悯憫,怃憮,忆憶,𢙐憹,𢙓懀,应應,怿懌,𢠁懎,怼懟,𫺊懠,𭝚懠,懑懣,㤽懤,恹懨,𫺪懩,𭜡懭,懒懶,懐懷,悬懸,𭞞懽,𭞹懽,慑懾,恋戀,𫺷戁,戆戇,㦮戔,戋戔,戗戧,戬戩,戦戰,𢧐戰,戏戲,挟挾,扪捫,𢪄捽,扫掃,抡掄,㧏掆,挜掗,拣揀,扬揚,挥揮,𫼝搊,损損,捣搗,抢搶,𫼱摃,𫼪摌,掴摑,掼摜,搂摟,捴摠,搃摠,𫼟摥,挚摯,抠摳,抟摶,掺摻,捞撈,𢭐撈,挦撏,挠撓,㧑撝,挢撟,掸撣,拨撥,𫝼撥,抚撫,揿撳,𫼧撶,挞撻,挝撾,捡撿,𢮦撿,拥擁,𫼮擃,掳擄,择擇,击擊,挡擋,㧟擓,㨈擠,挤擠,𢭏擣,㧛擥,𢬍擫,摈擯,搁擱,掷擲,扩擴,拡擴,撷擷,摆擺,擞擻,撸擼,㧰擽,摅攄,撵攆,拢攏,𢲣攏,𫽥攑,𫽻攑,拦攔,撄攖,𭢯攘,搀攙,撺攛,摂攝,摄攝,𫽋攞,攒攢,挛攣,摊攤,𭣇攧,搅攪,撹攪,揽攬,败敗,敌敵,数數,𭣧斁,㪘斂,敛斂,毙斃,𭤎斄,敩斆,斓斕,斩斬,断斷,𭤰旟,𠃓昜,时時,𣅢晬,晕暈,晖暉,旸暘,畅暢,暂暫,晔曄,晓曉,暁曉,暧曖,旷曠,昿曠,昽曨,𭧽曩,书書,会會,𦛨朥,𫆟朥,胧朧,𪱨朧,东東,𫠣柬,枧梘,条條,枭梟,枨棖,栆棗,栋棟,㭎棡,栈棧,桟棧,梾棶,桠椏,㭏椲,𣒌楇,杨楊,枫楓,桢楨,业業,杩榪,荣榮,榅榲,桤榿,枪槍,梿槤,椠槧,椮槮,桨槳,椢槶,椝槼,桩樁,乐樂,枞樅,楼樓,枢樞,㭤樢,𣔌樤,㭴樫,棇樬,桪樳,树樹,桦樺,𭫀樻,椫樿,桡橈,𣓤橈,桥橋,椭橢,𣓿橯,𬂰檂,柽檉,档檔,𭪆檛,桧檜,槚檟,检檢,検檢,樯檣,梼檮,槟檳,槛檻,𪲎櫅,橹櫓,栃櫔,榈櫚,栉櫛,椟櫝,橼櫞,栎櫟,𪲮櫠,橱櫥,櫉櫥,槠櫧,栌櫨,枥櫪,橥櫫,榇櫬,栊櫳,槞櫳,𪳥櫷,榉櫸,樱櫻,𬄩櫽,栏欄,𪳍欇,権權,𫞐權,椤欏,𪴙欑,栾欒,榄欖,𬄦欖,棂欞,𣠤欟,钦欽,𬅥歄,欧歐,㰸歛,欤歟,欢歡,歓歡,𭭕歡,亗歲,历歷,帰歸,归歸,残殘,殒殞,𣨼殢,殇殤,㱮殨,殚殫,殓殮,殡殯,㱩殰,殴毆,𪵑毊,毵毿,氇氌,気氣,氢氫,氩氬,氲氳,浃浹,泾涇,渌淥,沦淪,㳃淬,渊淵,涞淶,浅淺,沨渢,涡渦,测測,浑渾,浈湞,汤湯,𪶄溡,渓溪,浉溮,涢溳,沧滄,灭滅,涤滌,荥滎,滞滯,渗滲,浒滸,浐滻,满滿,渔漁,溇漊,𬇹漍,沤漚,涟漣,渍漬,涨漲,渐漸,𬇵漹,浆漿,颍潁,泼潑,溌潑,沩潙,㴋潚,润潤,𬈁潬,浔潯,溃潰,涠潿,涩澀,渋澁,𣶩澅,浇澆,𣷝澆,涝澇,𭱊澒,涧澗,渑澠,𭰎澢,泽澤,滪澦,泶澩,浍澮,㳠澾,浓濃,㳡濄,𣸣濆,𬈧濇,湿濕,溁濚,浕濜,㴉濟,济濟,済濟,𣺃濟,𣺴濟,𣽱濟,涛濤,𭱹濤,㳔濧,滥濫,潍濰,滨濱,溅濺,泺濼,滤濾,澛瀂,滢瀅,涜瀆,渎瀆,㲿瀇,泻瀉,渖瀋,浏瀏,濒瀕,泸瀘,沥瀝,潇瀟,潆瀠,𬉋瀢,潴瀦,泷瀧,滝瀧,濑瀨,潋瀲,𪶳瀺,澜瀾,滠灄,潅灌,𫞝灍,𪷽灒,滩灘,灏灝,㳕灡,湾灣,滦灤,滟灧,乌烏,烃烴,𬮟焛,无無,𪸩煇,炼煉,炜煒,茕煢,烦煩,炀煬,㶽煱,𬊂煼,煴熅,荧熒,𤆡熓,𬊎熕,炝熗,𤇹熚,焧熜,𤋏熡,𬉼熰,颎熲,𬊤燀,烨燁,烧燒,焼燒,𬊈燖,烫燙,焖燜,营營,烩燴,𬊉燵,㶶燶,烬燼,𬊍燽,焘燾,𫞡爃,烁爍,烂爛,为爲,爷爺,牍牘,牵牽,𬌝犓,荦犖,𪺭犞,㸿犢,犊犢,状狀,狭狹,狈狽,𪺽猌,𤝊猝,狲猻,犸獁,狱獄,狮獅,𪺷獊,奖獎,狯獪,猃獫,㺍獱,猟獵,犷獷,獭獺,猡玀,𤞤玁,𫞥珼,现現,珲琿,玮瑋,玚瑒,𭹗瑠,琐瑣,莹瑩,𭸼瑩,玛瑪,玱瑲,琏璉,𫞩璊,𬍤璕,𬍡璗,𭹲璛,𪻺璝,琎璡,瑷璦,珰璫,㻅璯,玙璵,瑸璸,玺璽,𫞦璾,𭹹瓌,珑瓏,珱瓔,璎瓔,瓒瓚,瓯甌,畄留,毕畢,𫼣畢,画畫,当當,𪽈畼,畴疇,𭻪疇,疂疊,痉痙,疩瘁,痖瘂,疯瘋,疡瘍,𬏮瘑,𬏫瘒,瘗瘞,疮瘡,疟瘧,瘆瘮,疭瘲,瘘瘻,疗療,痨癆,㾱癈,瘅癉,疠癘,瘪癟,𤸾癠,𤸜癢,疖癤,疬癧,癞癩,癣癬,瘿癭,瘾癮,痈癰,瘫癱,癫癲,発發,皑皚,𤾀皟,皲皸,皱皺,盏盞,𥁫盞,监監,卢盧,𪾔盨,𪾣眝,𬑆睔,睐睞,𥄌睟,𠬤睪,𬑕睴,眍瞘,䁖瞜,瞒瞞,𬑓瞱,瞆瞶,睑瞼,𥇥瞼,𪾸矉,𬑧矊,𭾦矌,𪾦矑,眬矓,𥉫矓,矫矯,硁硜,硖硤,砗硨,砚硯,𥒎碊,砕碎,硕碩,砀碭,砜碸,码碼,䂵碽,硙磑,砖磚,硵磠,碜磣,碛磧,矶磯,𮀤磱,硗磽,䃅磾,硚礄,硷礆,础礎,𬒈礐,𥐟礒,矿礦,砿礦,砺礪,砾礫,砻礱,𪿿礹,祸禍,祯禎,祎禕,祃禡,禅禪,祷禱,𮂜禳,䅉稏,䅟穇,稣穌,颖穎,秾穠,穑穡,秽穢,𥡒穧,𬓼穨,稳穩,穞穭,穣穰,窝窩,窎窵,窭窶,窥窺,窦竇,竃竈,𥩟竚,竖竪,𫁟竱,㐧第,笕筧,䇲筴,䇳箋,笺箋,筼篔,𥬠篘,筿篠,𬕂篢,笃篤,筛篩,筚篳,𥮾篸,箦簀,篓簍,箪簞,简簡,篑簣,箫簫,簘簫,筜簹,签簽,篮籃,筹籌,䉤籔,篯籛,箨籜,籁籟,笼籠,篭籠,笾籩,簖籪,𬖃籫,𬕄籭,箩籮,𬖑粯,粋粹,糁糝,粪糞,粝糲,纟糹,𫄙糺,纠糾,纪紀,纣紂,约約,红紅,纡紆,纥紇,纨紈,纫紉,纹紋,𬘕紌,纳納,纽紐,纾紓,纯純,纰紕,纼紖,纱紗,纮紘,纸紙,级級,纷紛,纭紜,纴紝,𬘘紞,𫄛紟,纺紡,𮉢紩,䌷紬,细細,绂紱,绁紲,绅紳,纻紵,𬘛紶,绍紹,绀紺,绋紼,𬘝紾,绐紿,绌絀,𫄟絁,终終,组組,䌹絅,绊絆,绗絎,结結,𮉤絓,绝絕,𬘢絖,𫄠絙,绔絝,绞絞,𬘠絠,络絡,绚絢,𬘟絤,𫄢絥,给給,𫄡絧,绒絨,𬘡絪,绖絰,统統,丝絲,绛絳,𬘖絸,绢絹,𫄨絺,𬘤絽,𦈌綀,绑綁,绡綃,𬘫綄,绠綆,绨綈,绣綉,绤綌,𬘩綎,绥綏,䌼綐,経經,经經,𬘨綕,𫄧綖,综綜,𬘭綝,缍綞,𫄫綟,绿綠,绸綢,绻綣,𬘯綧,𬘬綪,绶綬,维維,绹綯,绾綰,䋄綱,纲綱,绷綳,缀綴,䌽綵,紣綷,𮉬綷,纶綸,绺綹,绮綺,绽綻,绰綽,绫綾,绵綿,绲緄,𮉪緅,缁緇,𮉧緉,紧緊,绯緋,𮉫緌,𦈏緍,绪緒,绬緓,缃緗,缄緘,缂緙,线線,缐線,𬘰緛,缉緝,缎緞,缔締,缗緡,缘緣,𫄬緤,缌緦,𬘶緧,编編,缓緩,缅緬,𫄭緮,纬緯,𦈕緰,缑緱,缈緲,练練,缏緶,𦈉緷,𦈑緸,缇緹,𮉨緺,𬘵縆,萦縈,缙縉,缢縊,缒縋,𫄰縍,𦈔縎,䋓縐,绉縐,缣縑,缊縕,缞縗,𬘺縚,缚縛,缜縝,缟縞,缛縟,县縣,绦縧,𮉯縩,缝縫,𦈚縬,缡縭,缩縮,𬙂縯,𫄳縰,纵縱,缧縲,䌸縳,缦縵,絷縶,缕縷,𫃵縷,𫄲縸,缥縹,𦈐縺,绩績,𮉮繀,𫄴繂,缫繅,缪繆,𬙇繎,𦈝繏,缯繒,𦈛繓,织織,缮繕,𬙈繗,𬙆繙,缭繚,绕繞,𦈎繟,繍繡,缋繢,𫄶繦,𫄤繨,䋲繩,縄繩,绳繩,絵繪,绘繪,𫄱繬,缰繮,缳繯,缲繰,缴繳,𬙉繵,𫄷繶,𫄣繷,䍁繸,绎繹,𦈡繻,継繼,继繼,缤繽,缱繾,䍀繿,𫄸纁,緕纃,𬘧纃,𬙊纆,颣纇,缬纈,纩纊,続續,续續,缠纏,𮉡纑,䋝纓,缨纓,𦂯纔,𬙋纕,繊纖,𫄹纗,缵纘,𫄥纚,缆纜,䓨罃,罂罌,𬙎罏,𮉸罐,罓网,罚罰,骂罵,罢罷,𬙝罼,罗羅,罴羆,羁羈,𬙯羜,羟羥,义義,𫅗羵,习習,翆翠,𫩅翠,翚翬,翙翽,耧耬,耢耮,闻聞,联聯,聪聰,耸聳,聩聵,聂聶,职職,𫆏聻,聋聾,粛肅,肃肅,胁脅,䏮脇,胫脛,胀脹,肾腎,胨腖,脶腡,脑腦,脳腦,𣍯腪,肠腸,䒿膋,𬁵膒,腘膕,𦛢膕,䏝膞,𦝼膢,腻膩,𪱥膹,脍膾,脓膿,脸臉,脐臍,𦜝臍,膑臏,𫞇臘,胪臚,脔臠,臜臢,临臨,𫝌與,兴興,㪯舉,举舉,挙舉,𫽛舉,舱艙,𫇛艣,舣艤,舻艫,艰艱,艳艷,刍芻,苎苧,荘莊,茎莖,荚莢,苋莧,华華,𦬡萃,苌萇,莱萊,荝萴,莴萵,荭葒,荮葤,苇葦,荤葷,莼蒓,莳蒔,𫇴蒭,苍蒼,荪蓀,盖蓋,𦰏蓧,莲蓮,荜蓽,𦲞蔘,蒌蔞,蒋蔣,茑蔦,荫蔭,𬜿蔮,𫇭蔿,荨蕁,蒇蕆,荞蕎,荬蕒,莸蕕,荛蕘,蒉蕢,荡蕩,芜蕪,䔥蕭,萧蕭,蓣蕷,𫇽蕽,蕰薀,荟薈,蓟薊,芗薌,蔷薔,荙薘,莶薟,𮐚薠,萨薩,𬝯薲,䓕薳,䓓薵,荠薺,萕薺,蓝藍,荩藎,𬜾藖,药藥,薮藪,䓖藭,苈藶,蔼藹,蔺藺,萚蘀,蕲蘄,苏蘇,蕴蘊,藓蘚,蔹蘞,𦻕蘟,𮐨蘡,茏蘢,兰蘭,𬞕蘭,萝蘿,𦲿蘿,虏虜,蛱蛺,蜕蛻,蚬蜆,𬠔蜵,蚀蝕,蜗蝸,蛳螄,蚂螞,萤螢,䗖螮,蝼螻,螀螿,蛰蟄,蝈蟈,螨蟎,𫊸蟜,𮔚蟧,蝉蟬,蛲蟯,𫊻蟳,蛏蟶,𬠅蟷,蚁蟻,蚃蠁,蝇蠅,蝿蠅,虿蠆,蛴蠐,蝾蠑,𧏖蠙,蝋蠟,蛎蠣,𫊮蠦,蟏蠨,𧏵蠬,蛮蠻,𠀄衛,袅裊,装裝,𮖁裲,裈褌,袆褘,𬡇褭,裤褲,裢褳,褛褸,亵褻,𫌀襀,㐮襄,裥襇,褝襌,袯襏,𫋹襓,𫋷襗,𫋻襘,裣襝,裆襠,褴襤,䙓襬,𮖱襭,袭襲,襕襴,𫌇襵,𬡷襸,见見,觃覎,规規,觅覓,视視,𬢊覗,觇覘,𫌪覛,𬢋覜,𬢌覟,觋覡,觍覥,觎覦,𬢎覩,觊覬,𬢒覭,觏覯,觐覲,𬢔覴,觑覷,覚覺,觉覺,览覽,觌覿,観觀,观觀,𬱏觀,𮗚觀,觞觴,觯觶,讠訁,订訂,讣訃,计計,讯訊,讧訌,讨討,讦訐,𫍙訑,讱訒,训訓,讪訕,讫訖,讬託,记記,讹訛,𫍛訜,讶訝,𫍚訞,讼訟,䜣訢,诀訣,讷訥,𫟞訨,讻訩,访訪,设設,许許,诉訴,诃訶,诊診,证証,诂詁,诋詆,𫟟詊,讵詎,诈詐,𫍡詑,诒詒,𫍜詓,诏詔,评評,诐詖,诇詗,诎詘,诅詛,𬣥詜,𬣞詝,词詞,诩詡,询詢,诣詣,试試,诗詩,诧詫,诟詬,诡詭,诠詮,诘詰,话話,该該,详詳,诜詵,𬣱詶,𫍣詷,诖詿,𫍥誂,诔誄,诛誅,诓誆,𫍪誋,认認,诳誑,诶誒,诞誕,诱誘,诮誚,语語,诚誠,诫誡,诬誣,误誤,诰誥,诵誦,诲誨,说說,𫍨誫,谁誰,课課,𫍮誳,𫟡誴,谇誶,𫍬誷,诽誹,𫍧誺,谊誼,訚誾,调調,谄諂,谆諄,谈談,诿諉,请請,诤諍,诹諏,诼諑,谅諒,𬢣諓,𬤀諕,论論,谂諗,谀諛,谍諜,谞諝,谝諞,诨諢,𫍩諣,谔諤,𫍳諥,谛諦,谐諧,谏諫,𫍝諫,谕諭,谘諮,𫍱諯,𫍰諰,讳諱,𬤇諲,谙諳,𫍯諴,谌諶,讽諷,诸諸,谚諺,𬤍諻,谖諼,诺諾,谋謀,谒謁,谓謂,诌謅,𫍸謆,𫍷謉,谎謊,谜謎,𫍲謏,谧謐,𧨞謑,谑謔,谡謖,谤謗,谦謙,谥謚,讲講,谢謝,谣謠,𧩟謥,谟謨,谪謫,谬謬,谫謭,𫍹謯,𫍴謱,𬤄謲,讴謳,𧦅謳,𬤆謴,𫍵謸,谨謹,谩謾,𫟠譂,𫍻譆,𫍢譊,谲譎,讥譏,𫍤譑,谮譖,识識,谯譙,谭譚,谱譜,𫍽譞,𬣭譡,𫍦譨,谵譫,译譯,议議,谴譴,护護,诪譸,𬢪譸,䛓譼,誉譽,𫍿譾,読讀,读讀,谉讅,变變,変變,𭐦變,詟讋,䜩讌,雠讎,谗讒,譲讓,让讓,𮙊讔,谰讕,谶讖,𬤮讚,岂豈,豮豶,䝙貙,贝貝,贞貞,贠貟,负負,财財,贡貢,贫貧,货貨,贩販,贪貪,贯貫,责責,贮貯,𫎓貯,贳貰,赀貲,贰貳,贵貴,贬貶,买買,𧹒買,贷貸,贶貺,费費,贴貼,贻貽,贸貿,贺賀,贲賁,赂賂,赁賃,贿賄,赅賅,资資,贾賈,贼賊,赃賍,赈賑,赊賒,宾賓,赇賕,𬥸賗,赒賙,赉賚,𮚅賚,赐賜,𫎩賝,赏賞,𧹖賟,赔賠,赓賡,䝨賢,贤賢,卖賣,売賣,賎賤,贱賤,赋賦,赕賧,质質,赍賫,账賬,𧹔賬,赌賭,䞐賰,赖賴,赗賵,𬥳賶,赚賺,赙賻,赛賽,赜賾,𬥞贂,𧹗贃,贽贄,赘贅,赟贇,赠贈,𫎫贉,赞贊,赡贍,赢贏,䝲贐,赆贐,赑贔,赎贖,赝贗,𫎦贚,赣贛,𫎬贛,𧹘赫,赪赬,赵趙,趋趨,趱趲,践踐,𬦧踚,𮛪蹊,跄蹌,跸蹕,蹒蹣,跷蹺,𫏋蹻,跶躂,踌躊,䠁躋,跻躋,𨂋躋,踯躑,跞躒,踬躓,蹰躕,𨀁躘,𨃸躘,跹躚,蹑躡,蹿躥,躜躦,躏躪,躯軀,𬧤軂,𮜶軇,车車,轧軋,轨軌,军軍,𫐄軏,轪軑,轩軒,轫軔,𫐅軕,轭軛,𫐇軜,软軟,轷軤,𫐉軨,轸軫,𫐊軬,𮝴軱,轱軲,𫐈軷,轴軸,轵軹,轺軺,轲軻,轶軼,轼軾,𫐌軿,𮝵輀,较較,辂輅,𬨇輆,辁輇,辀輈,载載,轾輊,辄輒,𬨈輓,辅輔,軽輕,轻輕,𫐏輖,𫐐輗,輌輛,辆輛,辎輜,辉輝,辋輞,辍輟,𫐎輢,辊輥,辇輦,𫐑輨,辈輩,轮輪,辌輬,𫐓輮,辑輯,辏輳,𮝸輴,𬨍輵,𬨎輶,𫐒輷,输輸,辐輻,辗輾,舆輿,辒轀,毂轂,辖轄,辕轅,辘轆,𫐖轇,𬨓轈,转轉,𫐕轊,辙轍,轿轎,𫐗轐,𮝷轒,辚轔,𮝺轕,𫐘轗,𮝹轘,𬛼轝,軣轟,轰轟,𨋌轟,辔轡,轹轢,𫐆轣,轳轤,辫辮,辩辯,农農,迳逕,连連,进進,违違,遥遙,逊遜,迟遲,遅遲,𨒈遲,选選,遗遺,辽遼,迈邁,逻邏,𨔍邏,逦邐,郏郟,𬩾郲,郓鄆,邹鄒,邬鄔,郧鄖,𫑘鄟,邓鄧,𬩽鄩,郑鄭,𬪍鄮,郸鄲,邺鄴,郐鄶,邝鄺,酂酇,郦酈,酔醉,酝醞,蒏醟,𮠳醦,𬪧醧,酱醬,酦醱,醗醱,𬪩醲,醸釀,酾釃,酽釅,释釋,钅釒,钆釓,钇釔,钌釕,钊釗,钉釘,钋釙,𫟲釚,针針,𫓥釟,钓釣,钐釤,钏釧,𫓦釨,钒釩,𮣲釭,𫟳釲,钗釵,钍釷,钕釹,钎釺,𬬲釽,䥺釾,𬬱釿,钯鈀,钫鈁,𬬵鈂,钭鈄,𫓪鈆,𫓧鈇,钚鈈,钠鈉,𨱂鈋,钝鈍,钩鈎,钤鈐,钣鈑,钑鈒,钞鈔,钮鈕,𫟴鈖,𫟵鈗,𫓨鈛,𮣳鈜,钧鈞,钟鈡,钙鈣,钬鈥,钛鈦,钪鈧,铌鈮,𨱄鈯,铈鈰,𨱃鈲,钶鈳,铃鈴,钴鈷,钹鈸,铍鈹,钰鈺,钸鈽,铀鈾,钿鈿,钾鉀,铁鉄,钜鉅,钻鉆,铊鉈,铇鉋,铋鉍,铂鉑,钷鉕,钳鉗,铆鉚,铅鉛,𫟷鉝,钺鉞,𫓭鉠,钵鉢,钲鉦,鿭鉨,钼鉬,钽鉭,𬬹鉮,铏鉶,𫟹鉷,铰鉸,铒鉺,铬鉻,𫟸鉽,𫓴鉾,铪鉿,银銀,𫟻銂,铳銃,铜銅,𫓯銈,𫓰銊,铚銍,铣銑,钘銒,铨銓,铢銖,铭銘,铫銚,铦銛,衔銜,铑銠,铷銣,铱銥,铟銦,铵銨,铥銩,铕銪,铯銫,铐銬,铞銱,𬭍銲,锐銳,销銷,锈銹,锑銻,𮡪銻,锉銼,铝鋁,锒鋃,锌鋅,钡鋇,𮣴鋋,铤鋌,铗鋏,𬭎鋐,锋鋒,𬭌鋘,铻鋙,锊鋝,锓鋟,铘鋣,锄鋤,锃鋥,锔鋦,锇鋨,铓鋩,铺鋪,铖鋮,锆鋯,锂鋰,铽鋱,锍鋶,锯鋸,钢鋼,𬬭錀,锞錁,锖錆,锫錇,锩錈,铔錏,锥錐,锕錒,锟錕,锤錘,锱錙,铮錚,锛錛,𫓻錜,𫓽錝,锬錟,锭錠,锜錡,銭錢,钱錢,𮣵錣,𫓹錤,𫓾錥,锦錦,锚錨,锠錩,锡錫,𬭕錭,锢錮,错錯,锰錳,铼錸,𫓸錽,锝鍀,锨鍁,锪鍃,钔鍆,锴鍇,锳鍈,𫔂鍉,𫔀鍊,锅鍋,𬫚鍋,镀鍍,𫔄鍒,锷鍔,铡鍘,钖鍚,锻鍛,锽鍠,𬭡鍣,锸鍤,锲鍥,锘鍩,锹鍬,𬭤鍭,𨱎鍮,锾鍰,键鍵,锶鍶,锗鍺,锺鍾,镁鎂,锿鎄,镅鎇,𫟿鎈,镑鎊,𬭪鎋,𫔅鎍,𬭦鎒,𬭩鎓,镕鎔,锁鎖,𬬰鎗,镉鎘,𫔈鎙,𬭨鎚,镈鎛,𨱏鎝,𫔇鎞,镃鎡,钨鎢,蓥鎣,镏鎦,铠鎧,铩鎩,锼鎪,镐鎬,镇鎭,镒鎰,镋鎲,镍鎳,镓鎵,鿔鎶,𨰾鎷,镎鎿,镞鏃,镟鏇,链鏈,𨱒鏉,𬭮鏋,镆鏌,镙鏍,𬭬鏏,镠鏐,镝鏑,𨨕鏒,𬭝鏒,𬭥鏓,铿鏗,锵鏘,𨪙鏘,𬭭鏚,镗鏜,镘鏝,镛鏞,铲鏟,镜鏡,镖鏢,镂鏤,𨩐鏤,𫔊鏥,𫓩鏦,錾鏨,镚鏰,铧鏵,镤鏷,镪鏹,䥽鏺,𬭸鏻,𫔌鏾,𬭢鐀,铙鐃,𫔍鐇,𫓱鐈,𬭏鐊,铴鐋,𫔎鐍,𨱓鐎,镣鐐,铹鐒,镦鐓,镡鐔,镫鐙,镢鐝,镨鐠,䦅鐥,锎鐦,锏鐧,镄鐨,𫓺鐪,镌鐫,镰鐮,䦃鐯,镯鐲,镭鐳,镮鐶,铎鐸,铛鐺,𫟰鐺,𮣷鐻,𫔁鐼,𫟼鐽,镱鐿,鋳鑄,铸鑄,𮢷鑄,𬭉鑇,𮢕鑇,𫠁鑉,镬鑊,镔鑌,鉴鑒,镲鑔,锧鑕,鉱鑛,镴鑞,铄鑠,𬭔鑡,𮣁鑡,𮣶鑢,镳鑣,镥鑥,𬬻鑪,镧鑭,𬮁鑮,钥鑰,镵鑱,镶鑲,𮣐鑲,𫔔鑴,镊鑷,镩鑹,锣鑼,𬫤鑼,銮鑾,䦆钁,长長,门門,闩閂,闪閃,𬮘閄,𮤫閅,闫閆,闬閈,闭閉,𫔭開,闶閌,闳閎,闰閏,闲閑,𫔮閒,间間,闵閔,𫔯閗,闸閘,𬮠閜,𫠂閝,𫔰閞,阂閡,阁閣,𬮤閤,阀閥,𬮥閦,𬮢閧,闺閨,闽閩,阃閫,阆閬,闾閭,阅閱,𫔴閵,阊閶,阉閹,阎閻,阏閼,阍閽,阈閾,阌閿,阒闃,𬮲闄,闱闈,𬮱闉,阔闊,阕闋,阑闌,阇闍,阗闐,𫔶闑,阘闒,闿闓,阖闔,阙闕,闯闖,関關,阚闞,阓闠,阐闡,阛闤,闼闥,陉陘,陕陝,阵陣,陈陳,陆陸,队隊,阶階,陨隕,𬮻隖,际際,𬯎隤,随隨,险險,険險,𨹶隮,𨻕隮,𫕅隮,𬯀隮,陦隯,隐隱,𮥠隳,陇隴,𮥶雚,𮥹雚,雏雛,鸡雞,难難,雾霧,霁霽,𬰁霽,雳靂,霭靄,叇靆,𩄱靇,𩆇靇,叆靉,靓靚,靔靝,𫩑面,䩄靦,𫖃靧,靥靨,绱鞝,鞒鞽,𫖇鞾,鞑韃,韦韋,韧韌,韨韍,韩韓,𮧴韔,韪韙,𫖔韛,韬韜,𫖕韝,韫韞,𫖒韠,𮧵韡,页頁,顶頂,顷頃,𬱓頄,项項,顺順,顸頇,须須,顼頊,顾頋,颂頌,𫠆頍,颀頎,颃頏,预預,顽頑,颁頒,顿頓,𬱖頔,颇頗,领領,颌頜,颉頡,颐頤,颏頦,𫖯頫,颒頮,頬頰,颊頰,颋頲,颕頴,𫖳頵,颔頷,頚頸,颈頸,𩒍頸,颓頹,频頻,𩖖顃,𫖶顅,颗顆,题題,额額,颚顎,颜顏,𬱢顐,颙顒,颛顓,𫖮顗,𫖸願,颡顙,颠顛,颟顢,𫖹顣,颢顥,𮨇顧,颤顫,颥顬,显顯,顕顯,颦顰,颅顱,颞顳,颧顴,风風,飐颭,飑颮,飒颯,𬱻颯,飓颶,𩙪颷,飔颸,飏颺,飖颻,飕颼,𬳳颿,飗飀,𮨵飂,飘飄,飙飆,飚飇,飞飛,饣飠,饥飢,饤飣,饦飥,𫗞飦,饨飩,饪飪,饫飫,饬飭,饭飯,饮飲,饴飴,𫗢飵,𫗣飶,饲飼,饱飽,饰飾,饳飿,饺餃,饸餄,饼餅,饷餉,养養,饵餌,饹餎,饻餏,饽餑,馁餒,饿餓,𫗦餔,馂餕,饾餖,𫗧餗,馀餘,𬳁餚,馄餛,馃餜,䬻餞,饯餞,馅餡,𫗠餦,𫗪餧,馆館,𫗬餪,𫗥餫,𫗫餬,𫗮餭,𬳆餰,𫗯餱,饧餳,𫗭餵,馉餶,馇餷,𩠌餸,馎餺,饩餼,馏餾,馊餿,𬳊饀,馌饁,馍饃,馒饅,馐饈,馑饉,馓饊,馈饋,馔饌,饶饒,𩜙饒,飨饗,𫗴饘,餍饜,馋饞,𩝎饞,𫗵饟,𫗩饠,馕饢,马馬,驭馭,冯馮,𫘛馯,驮馱,驰馳,驯馴,驲馹,𫘜馼,驳駁,𫘝駃,𬳶駉,𫘟駊,𬳴駍,𩧨駎,驻駐,驽駑,驹駒,𬳵駓,驵駔,驾駕,骀駘,驸駙,𩧫駚,驶駛,驼駝,𫘞駞,驷駟,骈駢,𫘠駤,𩧲駧,𩧴駩,𬳽駪,𫘡駫,骇駭,骃駰,骆駱,𮪢駴,𩧺駶,骎駸,𮪡駹,𬴀駺,𫘣駻,𬳿駼,骏駿,骋騁,骍騂,𫘤騃,𫘧騄,骓騅,𫘥騉,𫘦騊,骔騌,骒騍,骑騎,骐騏,𬴂騑,𩨀騔,骛騖,骗騙,𩨊騚,𫘩騜,𩨃騝,𬴃騞,𩨈騟,𫘨騠,𮪣騣,骙騤,䯄騧,𩨄騪,骞騫,骘騭,骝騮,𬴅騯,腾騰,𫘬騱,𮪤騲,𫘫騴,𫘪騵,驺騶,骚騷,骟騸,𬴆騹,𫘭騻,𫠋騼,骡騾,蓦驀,骜驁,骖驂,𬳯驂,骠驃,骢驄,𩨂驄,駆驅,驱驅,骅驊,𩧯驋,骕驌,𩥶驌,骁驍,𬴊驎,骣驏,𮪥驐,騨驒,𫘯驓,骄驕,𬴋驖,験驗,验驗,𫘰驙,驿驛,骤驟,驴驢,骧驤,𩦪驤,骥驥,骦驦,𫘱驨,𩦘驩,𬴐驩,骊驪,骉驫,髅髏,髄髓,髌髕,髋髖,𩭹鬖,𬴩鬞,𫘽鬠,𮫂鬡,鬓鬢,闹鬧,阋鬩,䰗鬮,阄鬮,𩰘鬮,鬶鬹,魉魎,魇魘,鱼魚,鱽魛,𫚉魟,鱾魢,𮬛魣,𫚌魦,鲀魨,鲁魯,鲂魴,𫚍魵,鱿魷,鲄魺,𫠐魽,鲅鮁,鲆鮃,𫚒鮄,𫚑鮅,𫚖鮆,鲌鮊,鲉鮋,鲏鮍,鲇鮎,鲐鮐,鲍鮑,鲋鮒,鲊鮓,𬶌鮘,鲒鮚,鲘鮜,鲕鮞,𩽾鮟,䲟鮣,𫚓鮤,鲖鮦,𮬜鮨,鲔鮪,鲛鮫,鲑鮭,鲜鮮,𫚗鮯,𫚔鮰,鲓鮳,𫚛鮵,鲪鮶,鲝鮺,𫚚鮿,鲧鯀,鲠鯁,𫚙鯆,鲩鯇,鲤鯉,鲨鯊,鲬鯒,鲻鯔,鲯鯕,鲭鯖,鲞鯗,鲷鯛,鲴鯝,𫚡鯞,鲱鯡,鲵鯢,鲲鯤,鲳鯧,鲸鯨,鲮鯪,鲰鯫,𫚞鯬,鲶鯰,鲺鯴,𩽼鯶,鳀鯷,𬶢鯹,𬶟鯻,鲫鯽,𫚣鯾,鳊鯿,鳈鰁,鲗鰂,鳂鰃,䲠鰆,𬶧鰇,鲽鰈,鳇鰉,𬶠鰊,𫚢鰋,䲡鰌,鳅鰍,鲾鰏,𫚊鰑,鳆鰒,鳃鰓,𫚥鰕,𬶞鰗,鳒鰜,鳑鰟,鳋鰠,鲥鰣,𫚕鰤,鳏鰥,𫚤鰦,䲢鰧,鳎鰨,鳐鰩,𫚦鰫,鳍鰭,鳁鰮,鲢鰱,鳌鰲,鳓鰳,鳘鰵,鲦鰷,鲣鰹,𮫹鰹,鯵鰺,鲹鰺,鳗鰻,鳛鰼,𫚧鰽,鳔鰾,𬶨鱀,鳉鱂,𫚋鱄,鳙鱅,𫠒鱆,𩾌鱇,鳕鱈,鳖鱉,𫚪鱊,𬶲鱌,鳟鱒,𬶛鱓,鳝鱔,鳜鱖,鳞鱗,鲟鱘,𬶮鱚,鲼鱝,𬶵鱞,鲎鱟,鲙鱠,𫚫鱢,鳣鱣,鳡鱤,𮬝鱥,鳢鱧,鲿鱨,鲚鱭,𫚈鱮,鳠鱯,𫚭鱲,𮬤鱵,鳄鱷,鲈鱸,𬶺鱹,鲡鱺,鸟鳥,凫鳧,鸠鳩,鸤鳲,凤鳳,鸣鳴,鸢鳶,𫛛鳷,𫛚鳽,䴓鳾,𫛜鴀,𮭢鴁,𫛞鴃,𫛝鴅,鸩鴆,鸨鴇,鸦鴉,𫛤鴐,鸰鴒,𫛡鴔,鸵鴕,𫁡鴗,鸳鴛,鸲鴝,鸮鴞,鸱鴟,鸪鴣,𫛣鴥,鸯鴦,鸭鴨,𫛦鴮,鸸鴯,鸹鴰,𪉆鴲,𫛩鴳,鸻鴴,䴕鴷,鸿鴻,𫛪鴽,鸽鴿,䴔鵁,鸺鵂,鸼鵃,𫛥鵊,鹀鵐,鹃鵑,鹆鵒,鹁鵓,𪉍鵚,鹈鵜,鹅鵝,𫛭鵟,鹄鵠,鹉鵡,𫛨鵧,𫛳鵩,鹌鵪,𫛱鵫,鹏鵬,鹐鵮,鹎鵯,𫛲鵰,鹊鵲,鹓鵷,鹍鵾,𬷼鶂,䴖鶄,鸫鶇,鹑鶉,鹒鶊,𫛵鶌,𫛶鶒,鹋鶓,𬸝鶕,鹙鶖,𫛸鶗,鹕鶘,鹗鶚,鹖鶡,𬸜鶣,鹛鶥,𫛷鶦,鹜鶩,䴗鶪,鸧鶬,莺鶯,𦾉鶯,鹟鶲,鹤鶴,𩿿鶵,𬸅鶵,鹠鶹,鹡鶺,鹘鶻,鹣鶼,鹚鷀,鹢鷁,鹞鷂,𮭨鷃,鶏鷄,𫛽鷅,𬆮鷇,䴘鷉,鹝鷊,𫜀鷐,鹧鷓,鹥鷖,鴎鷗,鸥鷗,鸷鷙,鹨鷚,𬸞鷜,𮭪鷞,𫜃鷣,𫛴鷤,鸶鷥,鹪鷦,𫜁鷩,鹔鷫,𬸪鷭,鹩鷯,𬸧鷰,鹫鷲,鹇鷳,𫜄鷷,鹬鷸,鹰鷹,鹭鷺,鸴鷽,㶉鸂,鹯鸇,䴙鸊,𫛢鸋,鹱鸌,𬸕鸎,鹲鸏,鸬鸕,鹴鸘,鹦鸚,鹳鸛,𬸱鸜,鹂鸝,鵉鸞,鸾鸞,鹾鹺,鹸鹼,𫠗鹼,盐鹽,𫝖麁,𬸾麡,麦麥,麸麩,𮮄麪,𮮆麭,𪎌麳,麹麴,麺麵,𫜑麷,黉黌,黪黲,黡黶,黩黷,黾黽,鼋黿,𠀻黿,𠒞黿,鼌鼂,𬹣鼄,鼍鼉,鼡鼠,亝齊,斉齊,斊齊,齐齊,斎齋,𮁶齋,𬹳齎,𮚁齎,齑齏,歯齒,齿齒,龀齔,𮮾齔,龁齕,𬹺齖,龂齗,𬹼齘,龅齙,龇齜,龃齟,𪗱齟,龆齠,𮯃齠,齢齡,龄齡,𫠚齣,龈齦,𮯅齦,𪘂齧,𫜩齧,𫜪齩,龊齪,𮯇齪,龉齬,𪘚齬,𫜭齭,𬺈齮,𫠜齯,𫜬齰,龋齲,𮯌齲,𫜮齴,𮯋齶,龌齷,𮯎齷,𬺎齹,𬺓齼,𬺔齽,𫜰齾,竜龍,龙龍,𡯃龍,𥪖龍,厐龎,庞龐,䶮龑,龚龔,龛龕,亀龜,龟龜,穐龝,𬓫龝,𩨎龭,䜤鿁,䲤鿐,鿒鿓,鿟鿠,𠀾𠁞,𠁵𠁹,𠆿𠌥,𫢨𠎒,𫢘𠏮,𫝋𠐊,𫢔𠐽,𫣛𠑲,㓆𠗣,𫥍𠘥,𦋦𠚢,𠛆𠞆,𫦉𠞭,𫩯𠹛,𫪅𠺮,𫪄𠼤,𪜎𠿕,𭈥𠿷,𠶁𡁎,𭈉𡄖,𭉼𡅧,𫭮𡍫,𫭼𡑍,𫭯𡑎,𡋗𡑭,𡏆𡒶,𫮇𡓃,𫝪𡟫,㛿𡠹,㛠𡢃,𭑸𡢿,𪨩𡸗,𪨹𡹬,𫵶𡺨,𫵹𡽵,𫷈𢄼,𢇥𢈼,𪪴𢍰,𢙑𢠼,㦈𢣏,𪬚𢣐,𪫡𢤩,𪬯𢤿,𫼲𢯦,𫼤𢯩,𪭝𢯷,𫼶𢱡,𫼾𢲩,𫼗𢲫,𫽲𢶑,𪭯𢶒,𫽔𢷃,𢫊𢷮,𫾁𢸴,𫿂𢿓,𫾳𣀘,𫞅𣎟,㭣𣙎,杤𣜜,㮠𣞁,𣞎𣠩,毶𣯶,𬇄𣰨,𫂱𣶒,㳢𣾷,𬈱𤀪,𪶒𤄷,𬇬𤅙,𬝃𤎤,𬊢𤐛,𬋃𤒦,𤐎𤓃,𪹠𤓌,𬊜𤓓,𬌒𤖛,𪺣𤘀,𬌥𤛠,𤙯𤛮,𫞢𤛱,𪺸𤠮,𤣋𤣤,𫞧𤩂,㻘𤪺,㻏𤫩,𬎬𤮦,𤯶𤰁,𭻔𤲓,痫𤺛,𪠏𥀬,𬐠𥂸,𬑇𥇔,𬑙𥌚,𪿊𥏝,𥐰𥕥,𬒊𥖩,𥓗𥖭,𥕁𥖭,𪿞𥖲,𪿵𥗇,𬒓𥗴,𬒇𥗺,𬒗𥗽,𬓱𥢊,䅪𥢢,𫞷𥢶,𫀮𥢷,𥢃𥣗,𫁳𥯤,𬔯𥱸,𮅎𥵛,𫁱𥶽,𬖖𥻤,𬖞𥻵,𥹥𥼽,𥺇𥽖,𬘔𥾝,𫄝𥾯,𦈈𥿊,𬘦𥿯,𮉥𦀎,𫄦𦀖,𦈒𦂅,𬘸𦂋,𦈗𦃄,𬘼𦃒,𬘽𦃘,𫄯𦃩,𬘞𦄋,𬘾𦄍,𬘿𦄧,𬘳𦄼,𫄪𦅇,𫄵𦅈,𬙅𦅷,𬙪𦌾,𡚎𦍉,𬁺𦜖,𬁸𦞛,𬁳𦟐,𬂂𦣇,𦟗𦣎,𬜔𦪭,𦫄𦫊,𬜺𦶆,𦴇𦾵,𬟾𧍴,𮓹𧏺,𫊹𧒯,𧒭𧔥,𧓰𧕃,𧒋𧖐,𬡎𧛸,䘞𧜗,䙊𧜵,𮖃𧜶,䘛𧝞,𫌋𧞫,𧝧𧟀,𬡠𧟌,𬢇𧠈,𬢍𧠵,𬢈𧡍,𬢏𧡪,𫌫𧡴,𬢓𧢍,𬢕𧣴,𫍞𧦝,𫍟𧦧,𬤂𧨾,𫍭𧩕,䜥𧩙,𬤅𧩦,𫍶𧩼,𬤕𧪦,谠𧫆,𬤈𧫚,𫍺𧫝,𬤠𧬌,𫍼𧬤,𬤖𧬪,𬣵𧬻,𫍾𧭈,𫍐𧭹,𬤯𧮈,𬤷𧰆,𫲜𧲕,𧳕𧳟,𭕆𧴪,购𧵈,䞌𧵳,𧹓𧶔,䞎𧶧,𬥼𧶲,𪠀𧷎,𫎨𧸘,𫬙𧸫,𬥿𧸳,𬦅𧼮,𫏌𨂐,𬦩𨃘,𬦹𨃜,𮛗𨆉,𬧑𨇍,𫏞𨇰,𫏑𨇽,𫏠𨈇,𬦾𨈇,𨂺𨈊,𬧩𨉹,䢀𨊰,䢁𨊸,𬨅𨋚,䢂𨋢,𬨋𨌄,𫐍𨌈,𬨏𨍐,𫐔𨍰,𬨐𨍹,𫐋𨎌,𬨒𨎩,𫯒𨑊,𮠍𨟚,𨡺𨣈,𨠨𨣧,𬪯𨤋,𨱀𨥛,䦀𨦫,𬭊𨧀,𬭐𨧚,䦁𨧜,𬭑𨧫,𫟽𨧰,𫓼𨨛,𫓿𨨢,𬭟𨨯,𬭠𨩨,𫟾𨩰,𫓮𨪕,𬭧𨪵,𬭫𨫀,𬭱𨬂,𫔏𨬖,𬬶𨬞,𬭷𨭃,𬭶𨭆,𬭳𨭎,𬭙𨭐,𫔑𨭖,𬭇𨭗,𬭺𨭚,𫔐𨭸,𫔒𨮳,𬭿𨯀,䥿𨯅,𮢽𨯗,𫔓𨯟,𬮀𨯵,𫔕𨰥,𬮃𨰭,𫔃𨰲,𬮄𨲭,𫔖𨲳,𨸁𨳑,𮤭𨳒,𬮡𨳿,𬮣𨴑,𫔲𨴹,𮤸𨶯,𬮹𨶿,𬮙𨷈,𫔳𨷯,𬮷𨷯,𨴦𨷶,𫔸𨷶,𬮌𨷶,䦰𨷺,𮤾𨽏,𩂑𩄏,𫕨𩅙,𬰡𩉙,𫖑𩎖,𩏾𩎢,𫖓𩏂,𬰵𩏌,𫖖𩏠,𫖪𩑔,𬱔𩑣,𬱕𩑦,𫖭𩒎,𬱡𩒜,𬱤𩒲,𩖕𩓣,𫖵𩓥,𬱨𩓹,𬺂𩖁,𫗁𩘩,𫗂𩘬,𩙬𩘺,𩟿𩚛,𫗡𩚩,𫗨𩛡,𩠊𩜵,𬳇𩝑,𬳌𩝠,𬳈𩝡,𬳉𩝣,𬲰𩞃,𬳒𩞬,䭪𩞯,𩠅𩟐,𬳔𩟠,𩧦𩡺,𬳷𩢍,𩧬𩢡,𬳺𩢲,𩧵𩢴,𩧳𩢸,𬳻𩢼,𩧮𩢾,𬳼𩣋,𩧶𩣏,䯃𩣑,𬳹𩣔,𩧻𩣵,𩧼𩣺,𩧩𩤊,𩨆𩤙,𩨉𩤲,𬴄𩤵,𩨅𩤸,𩨋𩥄,𩨍𩥇,𩧱𩥉,𩨌𩥑,𬴇𩥲,𬴈𩥼,𬴉𩦚,𫠌𩦠,𬴌𩦺,𩨐𩧆,𬴎𩧐,𩬾𩭯,𫙂𩯁,𩯒𩯳,𩲒𩳤,𫚎𩶁,䲞𩶘,𫚝𩸄,𬶝𩸩,𬶜𩸬,𬶦𩹊,𬶡𩹝,𬶘𩹡,𬶩𩹽,𬶪𩺝,𫚨𩻗,𫚩𩻬,𫚘𩻮,𫚬𩼶,𬶳𩽈,𩺒𩽝,𫙭𩽝,𫠖𩿅,𫛠𩿤,𬸁𩿺,𬸂𪀉,𫛧𪀖,𮭦𪁏,𫛻𪃒,𫛹𪃧,𬸟𪃮,𫜂𪅂,𬸍𪇘,𪉕𪇳,𬸄𪈗,𮬽𪈰,𬸶𪉨,𫜊𪉸,𮮅𪌒,𫜓𪌭,𫜕𪍠,𬹗𪑚,𬹕𪑳,𬹖𪒬,𬹘𪒿,𬹤𪓽,𪔭𪔵,𬹽𪗜,𬹻𪗝,𬹿𪗪,𬺀𪗭,𬹾𪗳,𬺁𪗻,𬺄𪗽,𪚏𪘀,𬺇𪘓,𬺆𪘞,𬺋𪘧,𬺊𪘩,𪚐𪘯,𬺌𪘲,𬺏𪙍,𫜯𪙏,𬺑𪙑,𬺐𪙕,𬺅𪙞,𬺒𪙤,𬺖𪚅,𫢟𪝖,𫼽𪮰,𭡆𪯂,𣶭𪷓,𬖟𫃐,𮉩𫃥,𮉭𫃷,𬘹𫄇,𮎍𫇠,𬠈𫋐,𬡱𫌙,𬭋𫒞,𬳄𫗕,𫜫𫜦,𫢲𫣴,𫦰𫦸,𪠃𫨑,𫫏𫬆,𪯼𬀛,𪷚𬉬,𬌠𬌦,𬑍𬑡,𬒄𬒒,𬘣𬗏,𬙏𬙔,𬣫𬣍,𬦀𬥲,𬧔𬧙,𬮝𬮇,𮤷𬮍,𬯊𬯘,𬱩𬱈,𫗲𬲛,𬶑𬵮,𭃀𭃁,𭲍𭳯,𤇻𭶙,谳𮘾,𬧏𮜝,𮝳𮝄,𮤳𮤏,𮦅𮦗,𩌎𮧫,𬱾𮨭

這一字表來自 https://github.com/hfhchan/irg/blob/0b2e1fd3791ea4fcb72e141e781886b21d54eb87/kVariants.txt 中註 simp 的漢字。

為了保證轉換的準確性，在機器轉換後，還進行了人工校對。人工校對原則：只轉換有明確的簡體部件者。

- 第一類不轉換：「㝉」(cyu5) 不轉換為「宁」（對應關係錯誤）
- 第二類不轉換：「㪯」不轉換為「舉」（保留較生僻的異體字）
- 第三類不轉換：「蛻」不轉換為「蜕」（已經標註為異體字，即加註 0% 的字。這些字不是簡繁關係）

特例：「钟意」應轉換為「鍾意」，不是「鈡意」

特例：「䢂」不轉換為「𨋢」

因為

1. 已經收錄「𨋢」
2. 「䢂」在拓展A區，「𨋢」拓展B區。一些電腦程式不能處理「𨋢」，但能處理「䢂」
3. 「𨋢」字較常見，值得特殊處理

另外，詞庫中有些詞組原來簡繁兼收，因此此次更新除將簡體字修正外，還做了去重工作。

為便於檢查，機器轉換、人工校對、去重這三步分開進行，分三次提交。

</div>