### PR TITLE
IPA 聲調重碼

### DIFF
--- a/jyut6ping3_ipa.schema.yaml
+++ b/jyut6ping3_ipa.schema.yaml
@@ -116,12 +116,12 @@ translator:
     - xform/([ptk])q/$1˧/                     # 醃jiːp̚˧
     - xform/([ptk])v/$1˥/                     # 一jɐt̚
     - xform/vv/˨˩/                             # 而jiː˨˩
-    - xform/v/˥˥/                             # 衣jiː˥˥
+    - xform/v/˥/                              # 衣jiː˥
     - xform/xx/˩˧/                             # 以jiː˩˧
     - xform/x/˧˥/                              # 倚jiː˧˥
-    - xform/qq/˨˨/                            # 二jiː˨˨
-    - xform/(^|[ '])q/$1ʔ/                   # 喉塞音
-    - xform/q/˧˧/                             # 意jiː˧˧
+    - xform/qq/˨/                             # 二jiː˨
+    - xform/(^|[ '])q/$1ʔ/                    # 喉塞音
+    - xform/q/˧/                              # 意jiː˧
     - xform/([PTK])$/$1]$2/                   # 入jɐp̚
     - xform/(^|[ '])([jy])u(ng)/$1jʊŋ/        # 用jʊŋ
     - xform/(^|[ '])(jy|[jy])u([t])/$1jYː$3]/ # 月jyːt̚


### PR DESCRIPTION
IPA嘅粵語聲調符號應只有一粒，但係輸入法編輯器錯誤顯示咗兩粒。（「詩」應該係/siː˥/ 唔係 /siː˥˥/）

詳見 International Phonetic Association. (1999). Handbook of the International Phonetic Association: A guide to the use of the International Phonetic Alphabet. Cambridge, U.K: Cambridge University Press. 粵語示例，第五十九頁。(見下面嗰嗰截圖）