### PR TITLE
Fix 台/臺

### DIFF
--- a/jyut6ping3.dict.yaml
+++ b/jyut6ping3.dict.yaml
@@ -46409,8 +46409,8 @@ import_tables:
 漆樹科	cat1 syu6 fo1	
 七旋斬	cat1 syun4 zaam2	
 七碳糖	cat1 taan3 tong4	
-七台河	cat1 toi4 ho4	
-七台河市	cat1 toi4 ho4 si5	
+七臺河	cat1 toi4 ho4	
+七臺河市	cat1 toi4 ho4 si5	
 七橫八豎	cat1 waang4 baat3 syu6	
 七和弦	cat1 wo4 jin4	
 七仔	cat1 zai2	
@@ -64184,8 +64184,8 @@ import_tables:
 冬天	dung1 tin1	
 東鐵	dung1 tit3	
 東條英機	dung1 tiu4 jing1 gei1	
-東台	dung1 toi4	
-東台市	dung1 toi4 si5	
+東臺	dung1 toi4	
+東臺市	dung1 toi4 si5	
 東土	dung1 tou2	
 東討西征	dung1 tou2 sai1 zing1	
 東兔西烏	dung1 tou3 sai1 wu1	
@@ -66560,7 +66560,7 @@ import_tables:
 發帖	faat3 tip3	
 發貼	faat3 tip3	
 發條	faat3 tiu4	
-發台瘟	faat3 toi4 wan1	
+發臺瘟	faat3 toi4 wan1	
 發燙	faat3 tong3	
 發圖	faat3 tou4	
 發痛	faat3 tung3	
@@ -71511,8 +71511,8 @@ import_tables:
 豐田	fung1 tin4	
 封條	fung1 tiu4	
 風調雨順	fung1 tiu4 jyu5 seon6	
-豐台	fung1 toi4	
-豐台區	fung1 toi4 keoi1	
+豐臺	fung1 toi4	
+豐臺區	fung1 toi4 keoi1	
 楓糖	fung1 tong4	
 楓糖漿	fung1 tong4 zoeng1	
 封土	fung1 tou2	
@@ -71715,8 +71715,8 @@ import_tables:
 鳳頭雀嘴鵯	fung6 tau4 zoek3 zeoi2 bei1	
 奉天	fung6 tin1	
 奉天承運	fung6 tin1 sing4 wan6	
-鳳台	fung6 toi4	
-鳳台縣	fung6 toi4 jyun6	
+鳳臺	fung6 toi4	
+鳳臺縣	fung6 toi4 jyun6	
 奉還	fung6 waan4	
 奉爲圭臬	fung6 wai4 gwai1 jit6	
 鳳凰	fung6 wong4	
@@ -76544,8 +76544,8 @@ import_tables:
 九天攬月	gau2 tin1 laam5 jyut6	
 九鐵	gau2 tit3	
 九條街	gau2 tiu4 gaai1	
-九台	gau2 toi4	
-九台市	gau2 toi4 si5	
+九臺	gau2 toi4	
+九臺區	gau2 toi4 keoi1	
 九肚魚	gau2 tou5 jyu2	
 狗肚魚	gau2 tou5 jyu2	
 九肚魚	gau2 tou5 jyu4	
@@ -81388,7 +81388,7 @@ import_tables:
 高擡	gou1 toi4	
 高臺	gou1 toi4	
 高擡貴手	gou1 toi4 gwai3 sau2	
-高台縣	gou1 toi4 jyun6	
+高臺縣	gou1 toi4 jyun6	
 高湯	gou1 tong1	
 高唐	gou1 tong4	
 高堂	gou1 tong4	
@@ -103485,9 +103485,9 @@ import_tables:
 菸頭	jin1 tau2	
 煙頭兒	jin1 tau2 ji4	
 咽頭	jin1 tau4	
-煙台	jin1 toi4	
-煙台地區	jin1 toi4 dei6 keoi1	
-煙台市	jin1 toi4 si5	
+煙臺	jin1 toi4	
+煙臺地區	jin1 toi4 dei6 keoi1	
+煙臺市	jin1 toi4 si5	
 煙土	jin1 tou2	
 蔫土匪	jin1 tou2 fei2	
 煙囪	jin1 tung1	
@@ -104598,10 +104598,10 @@ import_tables:
 刑天	jing4 tin1	
 刑庭	jing4 ting4	
 瀛臺	jing4 toi4	
-邢台	jing4 toi4	
-邢台地區	jing4 toi4 dei6 keoi1	
-邢台縣	jing4 toi4 jyun6	
-邢台市	jing4 toi4 si5	
+邢臺	jing4 toi4	
+邢臺地區	jing4 toi4 dei6 keoi1	
+邢臺縣	jing4 toi4 jyun6	
+邢臺市	jing4 toi4 si5	
 刑堂	jing4 tong4	
 形同	jing4 tung4	
 形同虛設	jing4 tung4 heoi1 cit3	
@@ -105290,7 +105290,7 @@ import_tables:
 饒有風趣	jiu4 jau5 fung1 ceoi3	
 饒有興趣	jiu4 jau5 hing3 ceoi3	
 搖椅	jiu4 ji2	
-瑤台	jiu4 ji4	
+瑤臺	jiu4 ji4	
 徭役	jiu4 jik6	
 謠言	jiu4 jin4	
 謠言惑衆	jiu4 jin4 waak6 zung3	
@@ -107432,8 +107432,8 @@ import_tables:
 魚頭雲	jyu4 tau4 wan4	
 魚頭雲	jyu4 tau4 wan5	
 俞天白	jyu4 tin1 baak6	
-魚台	jyu4 toi4	
-魚台縣	jyu4 toi4 jyun6	
+魚臺	jyu4 toi4	
+魚臺縣	jyu4 toi4 jyun6	
 魚湯	jyu4 tong1	
 魚塘	jyu4 tong4	
 魚塘壆	jyu4 tong4 bok3	
@@ -107747,8 +107747,8 @@ import_tables:
 雨雲	jyu5 wan4	
 乳暈	jyu5 wan6	
 語域	jyu5 wik6	
-禹王台	jyu5 wong4 toi4	
-禹王台區	jyu5 wong4 toi4 keoi1	
+禹王臺	jyu5 wong4 toi4	
+禹王臺區	jyu5 wong4 toi4 keoi1	
 雨湖	jyu5 wu4	
 雨湖區	jyu5 wu4 keoi1	
 與會	jyu5 wui2	
@@ -110445,8 +110445,8 @@ import_tables:
 奇談怪論	kei4 taam4 gwaai3 leon6	
 奇蹄類	kei4 tai4 leoi6	
 奇蹄目	kei4 tai4 muk6	
-奇台	kei4 toi4	
-奇台縣	kei4 toi4 jyun6	
+奇臺	kei4 toi4	
+奇臺縣	kei4 toi4 jyun6	
 祈禱	kei4 tou2	
 祈禱文	kei4 tou2 man4	
 歧途	kei4 tou4	
@@ -116026,9 +116026,9 @@ import_tables:
 輪替	leon4 tai3	
 鱗頭樹鶯	leon4 tau4 syu6 ang1	
 輪胎	leon4 toi1	
-輪台	leon4 toi4	
-輪台古城	leon4 toi4 gu2 sing4	
-輪台縣	leon4 toi4 jyun6	
+輪臺	leon4 toi4	
+輪臺古城	leon4 toi4 gu2 sing4	
+輪臺縣	leon4 toi4 jyun6	
 輪滑	leon4 waat6	
 淪爲	leon4 wai4	
 鄰域	leon4 wik6	
@@ -116871,8 +116871,8 @@ import_tables:
 聆聽	ling4 ting3	
 菱鐵礦	ling4 tit3 kwong3	
 棱臺	ling4 toi4	
-靈台	ling4 toi4	
-靈台縣	ling4 toi4 jyun6	
+靈臺	ling4 toi4	
+靈臺縣	ling4 toi4 jyun6	
 靈堂	ling4 tong4	
 靈通	ling4 tung1	
 靈位	ling4 wai2	
@@ -117944,7 +117944,6 @@ import_tables:
 糧票	loeng4 piu3	
 梁山	loeng4 saan1	
 梁山伯	loeng4 saan1 baak3	
-梁山伯與祝英台	loeng4 saan1 baak3 jyu5 zuk1 jing1 toi4	
 梁山伯與祝英臺	loeng4 saan1 baak3 jyu5 zuk1 jing1 toi4	
 涼山彞族自治州	loeng4 saan1 ji4 zuk6 zi6 zi6 zau1	
 梁山縣	loeng4 saan1 jyun6	
@@ -128292,8 +128291,7 @@ import_tables:
 冒頭	mou6 tau4	
 冒天下之大不韙	mou6 tin1 haa6 zi1 daai6 bat1 wai5	
 帽天山	mou6 tin1 saan1	
-霧台	mou6 toi4	
-霧台鄉	mou6 toi4 hoeng1	
+霧臺	mou6 toi4	
 霧臺鄉	mou6 toi4 hoeng1	
 戊糖	mou6 tong4	
 募集	mou6 zaap6	
@@ -136560,8 +136558,8 @@ import_tables:
 拍拖	paak3 to1	
 拍拖報	paak3 to1 bou3	
 拍檯拍凳	paak3 toi2 paak3 dang3	
-帕台農	paak3 toi4 nung4	
-帕台農神廟	paak3 toi4 nung4 san4 miu2	
+帕臺農	paak3 toi4 nung4	
+帕臺農神廟	paak3 toi4 nung4 san4 miu2	
 拍檯拍凳	paak3 toi4 paak3 dang3	
 泊位	paak3 wai2	
 拍烏蠅	paak3 wu1 jing1	
@@ -140350,8 +140348,8 @@ import_tables:
 三天兩頭	saam1 tin1 loeng5 tau4	
 三田	saam1 tin4	
 三條	saam1 tiu4	
-三台	saam1 toi4	
-三台縣	saam1 toi4 jyun6	
+三臺	saam1 toi4	
+三臺縣	saam1 toi4 jyun6	
 三途川	saam1 tou4 cyun1	
 三通	saam1 tung1	
 三劃	saam1 waak6	
@@ -143554,7 +143552,6 @@ import_tables:
 新天地	san1 tin1 dei6	
 新田	san1 tin4	
 新田縣	san1 tin4 jyun6	
-新台幣	san1 toi4 bai6	
 新臺幣	san1 toi4 bai6	
 新塘	san1 tong4	
 新唐書	san1 tong4 syu1	
@@ -143884,13 +143881,11 @@ import_tables:
 神推鬼使	san4 teoi1 gwai2 si2	
 神推鬼㧬	san4 teoi1 gwai2 ung2	
 神推鬼擁	san4 teoi1 gwai2 ung2	
-神台	san4 toi2	
 神檯	san4 toi2	
-神台桔	san4 toi2 gat1	
 神檯桔	san4 toi2 gat1	
-神台貓屎	san4 toi2 maau1 si2	
-神台桔	san4 toi4 gat1	
-神台貓屎	san4 toi4 maau1 si2	
+神檯貓屎	san4 toi2 maau1 si2	
+神檯桔	san4 toi4 gat1	
+神檯貓屎	san4 toi4 maau1 si2	
 晨禱	san4 tou2	
 神通	san4 tung1	
 神通廣大	san4 tung1 gwong2 daai6	
@@ -146861,7 +146856,7 @@ import_tables:
 四會	sei3 wui6	
 四會市	sei3 wui6 si5	
 四仔	sei3 zai2	
-四仔台	sei3 zai2 toi4	
+四仔臺	sei3 zai2 toi4	
 四則	sei3 zak1	
 四則運算	sei3 zak1 wan6 syun3	
 四周	sei3 zau1	
@@ -148969,7 +148964,7 @@ import_tables:
 獅頭鵝	si1 tau4 ngo4	
 獅頭石竹	si1 tau4 sek6 zuk1	
 司天臺	si1 tin1 toi4	
-斯台普斯	si1 toi4 pou2 si1	
+斯臺普斯	si1 toi4 pou2 si1	
 斯托肯立石圈	si1 tok3 hang2 laap6 sek6 hyun1	
 司湯達	si1 tong1 daat6	
 絲絛	si1 tou1	
@@ -150747,9 +150742,8 @@ import_tables:
 先天愚型	sin1 tin1 jyu4 jing4	
 先天性	sin1 tin1 sing3	
 先天性缺陷	sin1 tin1 sing3 kyut3 haam6	
-仙台	sin1 toi4	
 仙臺	sin1 toi4	
-仙台市	sin1 toi4 si5	
+仙臺市	sin1 toi4 si5	
 仙桃	sin1 tou4	
 仙桃市	sin1 tou4 si5	
 仙童	sin1 tung4	
@@ -155203,7 +155197,7 @@ import_tables:
 臊鼠	sou1 syu2	
 騷體	sou1 tai2	
 蘇鐵	sou1 tit3	
-蘇台德地區	sou1 toi4 dak1 dei6 keoi1	
+蘇臺德地區	sou1 toi4 dak1 dei6 keoi1	
 蘇屋邨	sou1 uk1 cyun1	
 騷話	sou1 waa6	
 蘇維埃	sou1 wai4 aai1	
@@ -155923,7 +155917,6 @@ import_tables:
 送頭	sung3 tau4	
 餸頭餸尾	sung3 tau4 sung3 mei5	
 送還	sung3 waan4	
-宋王台	sung3 wong4 toi4	
 宋王臺	sung3 wong4 toi4	
 送往	sung3 wong5	
 送往迎來	sung3 wong5 jing4 loi4	
@@ -160884,7 +160877,7 @@ import_tables:
 檯子	toi2 zi2	
 檯薦	toi2 zin2	
 臺巴子	toi4 baa1 zi2	
-台伯河	toi4 baak3 ho4	
+臺伯河	toi4 baak3 ho4	
 臺胞	toi4 baau1	
 臺胞證	toi4 baau1 zing3	
 臺幣	toi4 bai6	
@@ -160896,12 +160889,11 @@ import_tables:
 臺磅	toi4 bong6	
 檯布	toi4 bou3	
 臺詞	toi4 ci4	
-台前	toi4 cin4	
-台前縣	toi4 cin4 jyun6	
+臺前	toi4 cin4	
+臺前縣	toi4 cin4 jyun6	
 臺菜	toi4 coi3	
 薹草	toi4 cou2	
 薹草屬	toi4 cou2 suk6	
-台柱	toi4 cyu5	
 臺柱	toi4 cyu5	
 臺柱子	toi4 cyu5 zi2	
 臺大	toi4 daai6	
@@ -160925,9 +160917,9 @@ import_tables:
 臺基	toi4 gei1	
 擡舉	toi4 geoi2	
 擡轎子	toi4 giu2 zi2	
-台江	toi4 gong1	
-台江縣	toi4 gong1 jyun6	
-台江區	toi4 gong1 keoi1	
+臺江	toi4 gong1	
+臺江縣	toi4 gong1 jyun6	
+臺江區	toi4 gong1 keoi1	
 擡槓	toi4 gong3	
 擡高	toi4 gou1	
 臺下	toi4 haa6	
@@ -161007,7 +160999,7 @@ import_tables:
 台州	toi4 zau1	
 台州地區	toi4 zau1 dei6 keoi1	
 台州市	toi4 zau1 si5	
-台姐	toi4 ze1	
+臺姐	toi4 ze1	
 臺資	toi4 zi1	
 臺子	toi4 zi2	
 臺座	toi4 zo6	
@@ -167100,7 +167092,7 @@ import_tables:
 烏喱馬扠	wu1 lei1 maa5 caa5	
 烏喱馬杈	wu1 lei1 maa5 caa5	
 烏喱馬紁	wu1 lei1 maa5 caa5	
-烏里雅蘇台	wu1 lei5 ngaa5 sou1 toi4	
+烏里雅蘇臺	wu1 lei5 ngaa5 sou1 toi4	
 污吏	wu1 lei6	
 烏倫古河	wu1 leon4 gu2 ho4	
 烏倫古湖	wu1 leon4 gu2 wu4	
@@ -167999,8 +167991,8 @@ import_tables:
 緩慢	wun4 maan6	
 援手	wun4 sau2	
 洹水	wun4 seoi2	
-桓台	wun4 toi4	
-桓台縣	wun4 toi4 jyun6	
+桓臺	wun4 toi4	
+桓臺縣	wun4 toi4 jyun6	
 桓桓	wun4 wun4	
 援助	wun4 zo6	
 援助交際	wun4 zo6 gaau1 zai3	


### PR DESCRIPTION
> Telegram 用戶交流組：[t.me/rime_cantonese](https://t.me/rime_cantonese)

https://github.com/rime/rime-cantonese/issues/29 中修復了部分「台」字，但還有一些詞（主要為地名）没有修復，本次修改修復了這些詞。

原因：rime-cantonese 的碼表中的詞語遵循 OpenCC 標準用字，區分台/臺/檯等字（香港不區分，均寫作「台」，若要達到此效果，在選單中選擇「香港傳統漢字」，程式會自動將詞條中的「臺」轉換為「台」）。

本次修改的主要依據為：

1. 在維基百科查找該地名的語源，若與「平臺」等義相關則用「臺」
1. 在谷歌圖片中查找縣名 + 「縣誌」，若搜索結果的縣誌圖片中寫「臺」，則用「臺」
1. 在中央研究院歷史語言研究所及計算中心製作的 [中國歷史地名查詢系統](http://archive.ihp.sinica.edu.tw/hplname/placename/basic) 中查找，若該網站用「臺」，則用「臺」（但不知為何，該網站用「台江」，依其他資料改為「臺江」）

另外，音譯的外國地名用「臺」。

最終，僅「台州」、「天台」及相關詞彙用「台」，「神檯」（供奉神靈之檯）用「檯」，其餘用「臺」。

另外，九臺市已改為九臺區，故在碼表中作同樣修改。