### PR TITLE
Add loengfan reverse lookup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ before_install:
   - export TRIME_LINK=https://github.com/osfans/trime/raw/gh-pages/release/app-release.apk
 
 # IME Files path
-  - export WEASEL_PACKAGES="cantonese emoji sgalal/rime-opencc-32bit-latest custom:set:config=default,key=installed_from,value=rime-cantonese custom:add:schema=jyut6ping3 lotem/rime-octagram-data lotem/rime-octagram-data@hant lotem/rime-octagram-data:customize:schema=jyut6ping3,model=hant"
-  - export SQUIRREL_PACKAGES="cantonese emoji sgalal/rime-opencc-latest custom:set:config=default,key=installed_from,value=rime-cantonese custom:add:schema=jyut6ping3 lotem/rime-octagram-data lotem/rime-octagram-data@hant lotem/rime-octagram-data:customize:schema=jyut6ping3,model=hant"
+  - export WEASEL_PACKAGES="cantonese emoji CanCLID/rime-loengfan sgalal/rime-opencc-32bit-latest custom:set:config=default,key=installed_from,value=rime-cantonese custom:add:schema=jyut6ping3 lotem/rime-octagram-data lotem/rime-octagram-data@hant lotem/rime-octagram-data:customize:schema=jyut6ping3,model=hant"
+  - export SQUIRREL_PACKAGES="cantonese emoji CanCLID/rime-loengfan sgalal/rime-opencc-latest custom:set:config=default,key=installed_from,value=rime-cantonese custom:add:schema=jyut6ping3 lotem/rime-octagram-data lotem/rime-octagram-data@hant lotem/rime-octagram-data:customize:schema=jyut6ping3,model=hant"
   - export IBUS_PACKAGES=${SQUIRREL_PACKAGES}
-  - export TRIME_PACKAGES=":preset cantonese emoji sgalal/rime-opencc-32bit-latest"
+  - export TRIME_PACKAGES=":preset cantonese emoji CanCLID/rime-loengfan sgalal/rime-opencc-32bit-latest"
 
 # Windows sfx installer header
   - export SFXHEADER=7zSD.sfx

--- a/README-cmn.md
+++ b/README-cmn.md
@@ -86,9 +86,10 @@ emoji 碼表請見[此處](https://github.com/rime/rime-emoji/tree/master/opencc
 
 ### 反查
 
-本方案支援普通話拼音、筆畫、倉頡反查，反查鍵：
+本方案支援普通話拼音、粵語兩分、筆畫、倉頡反查，反查鍵：
 
 - 普通話拼音：<kbd>`</kbd>
+- 粵語兩分：<kbd>r</kbd>
 - 筆畫：<kbd>x</kbd>
 - 倉頡五代：<kbd>v</kbd>
 

--- a/README-en.md
+++ b/README-en.md
@@ -84,9 +84,10 @@ Please use the following snippet under `switches` in `jyut6ping3.schema.yaml` to
 
 ### Reverse lookup
 
-This schema also allows the user to lookup Cantonese words with Mandarin Pinyin, stroke order and Cangjie code. Click the following button in edit mode to enable the respective reverse lookup option:
+This schema also allows the user to lookup Cantonese words with Mandarin Pinyin, Loengfan, stroke order and Cangjie code. Click the following button in edit mode to enable the respective reverse lookup option:
 
 - Mandarin Pinyin: <kbd>`</kbd>
+- Loengfan: <kbd>r</kbd>
 - Stroke order: <kbd>x</kbd>
 - Cangjie (5th gen): <kbd>v</kbd>
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ emoji 碼表可以喺[呢度](https://github.com/rime/rime-emoji/tree/master/ope
 
 ### 反查
 
-本方案支援普通話拼音、筆畫、倉頡反查，反查掣：
+本方案支援普通話拼音、粵語兩分、筆畫、倉頡反查，反查掣：
 
 - 普通話拼音：<kbd>`</kbd>
+- 粵語兩分：<kbd>r</kbd>
 - 筆畫：<kbd>x</kbd>
 - 倉頡五代：<kbd>v</kbd>
 

--- a/jyut6ping3.schema.yaml
+++ b/jyut6ping3.schema.yaml
@@ -4,7 +4,7 @@
 schema:
   schema_id: jyut6ping3
   name: 粵語拼音
-  version: "2020.08.03"
+  version: "2020.08.06"
   author:
     - sgalal <sgalal.me@outlook.com>
     - LeiMaau <leimaau@qq.com>
@@ -21,6 +21,7 @@ schema:
 
   dependencies:
     - luna_pinyin
+    - loengfan
     - stroke
     - cangjie5
 
@@ -55,6 +56,7 @@ engine:
     - ascii_segmentor
     - matcher
     - affix_segmentor@luna_pinyin
+    - affix_segmentor@loengfan
     - affix_segmentor@stroke
     - affix_segmentor@cangjie5
     - abc_segmentor
@@ -64,6 +66,7 @@ engine:
     - punct_translator
     - script_translator
     - script_translator@luna_pinyin
+    - script_translator@loengfan
     - table_translator@stroke
     - table_translator@cangjie5
   filters:
@@ -132,6 +135,13 @@ luna_pinyin:
     - xform/([nl])ue/$1üe/
     - xform/([jqxy])v/$1u/
 
+loengfan:
+  tag: loengfan
+  dictionary: loengfan
+  prefix: "r"
+  suffix: ";"
+  tips: 〔粵語兩分〕
+
 stroke:
   tag: stroke
   dictionary: stroke
@@ -186,5 +196,6 @@ recognizer:
   patterns:
     punct: "^/([0-9]0?|[a-z]+)$"
     luna_pinyin: "`[a-z']*;?$"
+    loengfan: "r[a-z']*;?$"
     stroke: "^x[hspnz]*;?$"
     cangjie5: "^v[a-z]*;?$"

--- a/jyut6ping3.schema.yaml
+++ b/jyut6ping3.schema.yaml
@@ -168,7 +168,7 @@ cangjie5:
     - "^yyy.*$"
 
 reverse_lookup:
-  tags: [ luna_pinyin, stroke, cangjie5 ]
+  tags: [ luna_pinyin, loengfan, stroke, cangjie5 ]
   overwrite_comment: false
   dictionary: jyut6ping3
 

--- a/jyut6ping3_ipa.schema.yaml
+++ b/jyut6ping3_ipa.schema.yaml
@@ -6,7 +6,7 @@ __include: jyut6ping3.schema:/
 schema:
   schema_id: jyut6ping3_ipa
   name: 粵語拼音（IPA版）
-  version: "2020.07.15"
+  version: "2020.08.06"
   author:
     - sgalal <sgalal.me@outlook.com>
     - LeiMaau <leimaau@qq.com>


### PR DESCRIPTION
This pull request add [Loengfan](https://github.com/CanCLID/rime-loengfan) (粵語兩分) as reverse lookup.

Loengfan enables users to input a character by the pronunciation of two parts. For example:

- 蒛 = 艹 (cou2) + 缺 (kyut3) = cou2kyut3
- 蒜 = 艹 (cou2) + 示 (si6) = cou2si6

Loengfan lets users to input many rare characters by Jyutping easily. This can be beneficial to Jyutping learners.