### PR TITLE
add 石𬒔 (sek6 gang2) and 𬒔 (gang2)

### DIFF
--- a/jyut6ping3.dict.yaml
+++ b/jyut6ping3.dict.yaml
@@ -8499,6 +8499,7 @@ import_tables:
 鯁	gang2
 𡍷	gang2
 𣆳	gang2
+𬒔	gang2
 堩	gang3	0%
 恆	gang3	3%
 揯	gang3	0%
@@ -150017,6 +150018,7 @@ import_tables:
 食夾棍	sek6 gaap3 gwan3
 石雞	sek6 gai1
 石敢當	sek6 gam2 dong1
+石𬒔	sek6 gang2
 石狗公	sek6 gau2 gung1
 石堅	sek6 gin1
 石景山	sek6 ging2 saan1


### PR DESCRIPTION
石𬒔村， 位於佛山市
證據：
- https://v.youku.com/v_show/id_XMzY1MDU2MTU0OA==.html
- https://v.qq.com/x/page/h0933cjl87f.html