### PR TITLE
Fix rime-deployer encode failure

### DIFF
--- a/jyut6ping3.dict.yaml
+++ b/jyut6ping3.dict.yaml
@@ -42279,7 +42279,7 @@ import_tables:
 波羅蓋	bo1 lo4 goi3
 菠蘿蓋	bo1 lo4 goi3
 菠蘿油	bo1 lo4 jau4
-菠蘿油王子 bo1 lo4 jau4 wong4 zi2
+菠蘿油王子	bo1 lo4 jau4 wong4 zi2
 菠蘿麻	bo1 lo4 maa4
 波羅蜜	bo1 lo4 mat6
 菠蘿蜜	bo1 lo4 mat6
@@ -125595,7 +125595,7 @@ import_tables:
 麥德龍	mak6 dak1 lung4
 麥德蒙	mak6 dak1 mung4
 麥兜	mak6 dau1
-麥兜菠蘿油王子 mak6 dau1 bo1 lo4 jau4 wong4 zi2
+麥兜菠蘿油王子	mak6 dau1 bo1 lo4 jau4 wong4 zi2
 墨斗	mak6 dau2
 麥豆	mak6 dau2
 驀地	mak6 dei6


### PR DESCRIPTION
修復此錯誤：

`rime-deployer --compile /usr/share/rime-data` 

![photo_2020-11-29_02-51-37](https://user-images.githubusercontent.com/19554922/100524128-7b91d900-31f0-11eb-8f74-37d32b2ba0c8.jpg)

我嘅 build log，可以正常 deploy：

![image](https://user-images.githubusercontent.com/19554922/100524129-8482aa80-31f0-11eb-8eab-29072c08010c.png)
