### PR TITLE
More lenient fuzzy matching for a->aa

### DIFF
--- a/jyut6ping3.schema.yaml
+++ b/jyut6ping3.schema.yaml
@@ -112,7 +112,7 @@ speller:
     - derive/eoi$/eoy/            # 容錯
     - derive/eo/oe/               # 容錯 eo/oe 不分
     - derive/oe(ng|k)$/eo$1/      # 容錯
-    - derive/aa$/a/               # 容錯
+    - derive/aa/a/                # 容錯
     - abbrev/^([a-z]).+$/$1/      # 首字母簡拼
     - abbrev/^([a-z]{2}).+$/$1/   # 首2字母簡拼
 


### PR DESCRIPTION
# Current situation

宜家淨係會係`aa`韻腳嗰時match埋`a`音

https://github.com/rime/rime-cantonese/blob/3b792daeb39f7f32c1ff31518e4dc3bfb182104e/jyut6ping3.schema.yaml#L115

即係話打`ban`係唔會出到`baan`（例如：板）嘅字

# Rational

`a`音同`aa`音成日會撈亂，即使係韻腳嘅其中一個部份

# Solutions from other IME

GBoard有將所有`a` match `aa`

![Screenshot_20201211-153949](https://user-images.githubusercontent.com/6838982/101876678-c683f700-3bc7-11eb-94b6-3b4456d03121.png)

# PR description

呢個PR會將全部`a`音容錯`aa`，即係例如打`ban`時會出埋`baan`嘅字