### PR TITLE
「囯囶囻圀」係「國」嘅異體字，唔可以讀gok3

### DIFF
--- a/jyut6ping3.dict.yaml
+++ b/jyut6ping3.dict.yaml
@@ -9540,10 +9540,6 @@ import_tables:
 傕	gok3
 各	gok3
 咯	gok3	3%
-囯	gok3	0%
-囶	gok3	0%
-囻	gok3	0%
-圀	gok3	0%
 埆	gok3
 崅	gok3	0%
 捔	gok3


### PR DESCRIPTION
詞表已經有「gwok3」音，唔使另外加返。