### PR TITLE
容错 aau --> ao

### DIFF
--- a/jyut6ping3.schema.yaml
+++ b/jyut6ping3.schema.yaml
@@ -117,6 +117,9 @@ speller:
     #- derive/p(?=\d)/t/
     #- derive/t(?=\d)/p/
 
+    # 取消下行註釋，容錯 aau -> ao
+    #- derive/aau$/ao/
+    
     - derive/^([aeiou])/q$1/      # 增加 q 表示喉塞
     - derive/^jy?([aeiou])/y$1/   # 容錯 je -> ye, jyu -> yu
     - derive/^jyu/ju/             # 容錯 jyu -> ju


### PR DESCRIPTION
普通话拼音的韵母“ao"同粤语拼音韵母”aau“系同音，
用开普通话拼音输入法嘅人刚刚开始转用粤拼输入法会容易搞错。
因此可提供 aau-->ao 的容错选项，方便刚刚从普通话拼音输入法转过嚟嘅用户适应。
粤拼中无”ao“呢个韵母，亦唔会冲突