### PR TITLE
Manage package list centrally in the `install` branch

### DIFF
--- a/.ci/install-schema.sh
+++ b/.ci/install-schema.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-curl -fsSL https://git.io/rime-install | bash -s -- prelude essay cantonese emoji-cantonese cangjie stroke luna-pinyin CanCLID/rime-loengfan lotem/rime-octagram-data lotem/rime-octagram-data@hant
 
-if [ -n "$rime_dir" ]; then
-  pushd "$rime_dir"
-  perl -0777 -i -pe 's/\nschema_list:\n.*?\n\n/
-installed_from: rime-cantonese
-
-schema_list:
-  - schema: jyut6ping3
-  - schema: cangjie5
-  - schema: stroke
-  - schema: luna_pinyin
-
-/s; s/page_size: [0-9]+/page_size: 8/' default.yaml
-  rm emoji_cantonese_suggestion.yaml
-  popd
-fi
+curl -fsSL https://git.io/rime-install | bash -s -- rime/rime-cantonese@install/clean-install-packages.conf
+rm clean-install-packages.conf

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -30,11 +30,9 @@ jobs:
         run: |
           chmod u+x ./.ci/*
           export rime_dir=~/.config/ibus/rime
-          curl -fsSL https://git.io/rime-install | bash -s -- :preset emoji CanCLID/rime-loengfan custom:set:config=default,key=installed_from,value=rime-cantonese custom:clear_schema_list custom:add:schema=jyut6ping3 custom:add:schema=cangjie5 custom:add:schema=stroke custom:add:schema=luna_pinyin lotem/rime-octagram-data lotem/rime-octagram-data@hant lotem/rime-octagram-data:customize:schema=jyut6ping3,model=hant
-          cp ./*.{txt,yaml} $rime_dir 
-          cp ./opencc/* $rime_dir
-
-# Use cp ./** in lieu of ./.ci/install_schema.sh to ensure that action is running on checked out branch (e.g. PR refs)
+          curl -fsSL https://git.io/rime-install | bash -s -- rime/rime-cantonese@install/clean-install-packages.conf
+          rm clean-install-packages.conf
+        # Replicate the content of ./.ci/install_schema.sh in lieu of calling it directly to ensure that action is running on checked out branch (e.g. PR refs)
 
       - name: Compile
         run: |


### PR DESCRIPTION
Background: the recipes and package lists in the `install` branch were created as a part of revising the documentation on [jyutping.net](https://jyutping.net) and the [wiki](https://github.com/rime/rime-cantonese/wiki). There were lots of different `curl -fsSL https://git.io/rime-install | bash` commands, some of which download unnecessary packages or apply redundant patches.
